### PR TITLE
Change instructions in README to use pyvenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,12 +57,12 @@ docs/_build/
 
 # PyBuilder
 target/
-### Example user template template
-### Example user template
 
 # IntelliJ project files
 .idea
 *.iml
 out
 gen
-# Created by .ignore support plugin (hsz.mobi)
+
+# Vim
+*.sw[op]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ To deactivate the virtual environment, just run:
 
     $ deactivate
 
+If you want easier handling of your virtualenvs, you might also want to take a
+look at [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/).
+
 ## Installation
 
 If you are using a virtual environment, activate it first.

--- a/README.md
+++ b/README.md
@@ -10,30 +10,23 @@ On machines where Python 3 is not the default Python runtime, you should use
 
 ## Prerequisites
 
-```
-$ sudo apt-get install python3 python3-pip
-```
+    $ sudo apt-get install python3 python3-pip
 
-We recommend using the [virtualenv](https://virtualenv.readthedocs.org/en/latest/)
-package to create an isolated Python environment:
+We recommend using [venv](https://docs.python.org/3/library/venv.html) to
+create an isolated Python environment:
 
-```
-$ sudo pip install virtualenv
-$ virtualenv -p python3 saltyrtc-server-venv
-```
+    $ pyvenv venv
 
-You can switch into the created virtual environment *saltyrtc-server-venv*
-by running this command:
+You can switch into the created virtual environment *venv* by running this
+command:
 
-```
-$ source saltyrtc-server-venv/bin/activate
-```
+    $ source venv/bin/activate
+
+All packages you install now with `pip` will be installed into your virtualenv.
 
 To deactivate the virtual environment, just run:
 
-```
-$ deactivate
-```
+    $ deactivate
 
 ## Installation
 


### PR DESCRIPTION
Python 3.3+ already ships an implementation of virtualenv, so no need for an additional package.