### PR TITLE
Accept binary data both as binary and as array data

### DIFF
--- a/saltyrtc/common.py
+++ b/saltyrtc/common.py
@@ -86,8 +86,8 @@ def validate_cookie(cookie):
     if not isinstance(cookie, bytes):
         raise MessageError('Invalid cookie: Must be `bytes` instance')
     if len(cookie) != COOKIE_LENGTH:
-        raise MessageError('Invalid cookie: Invalid length (%d != %d)'
-                % (len(cookie), COOKIE_LENGTH))
+        raise MessageError('Invalid cookie: Invalid length ({} != {})'.format(
+            len(cookie), COOKIE_LENGTH))
 
 
 def validate_initiator_connected(initiator_connected):

--- a/saltyrtc/message.py
+++ b/saltyrtc/message.py
@@ -260,7 +260,7 @@ class AbstractBaseMessage(AbstractMessage, metaclass=abc.ABCMeta):
         except KeyError as exc:
             error_message = 'Can not handle valid message type: {}'
             raise MessageError(error_message.format(type_)) from exc
-        message_class.check_payload(client, payload)
+        payload = message_class.check_payload(client, payload)
 
         # Return instance
         message = message_class(
@@ -404,7 +404,9 @@ class ServerHelloMessage(AbstractBaseMessage):
         """
         MessageError
         """
-        validate_public_key(_ensure_bytes(payload.get('key')))
+        payload['key'] = _ensure_bytes(payload.get('key'))
+        validate_public_key(payload['key'])
+        return payload
 
     @property
     def server_public_key(self):
@@ -428,7 +430,9 @@ class ClientHelloMessage(AbstractBaseMessage):
         """
         MessageError
         """
-        validate_public_key(_ensure_bytes(payload.get('key')))
+        payload['key'] = _ensure_bytes(payload.get('key'))
+        validate_public_key(payload['key'])
+        return payload
 
     @property
     def client_public_key(self):
@@ -452,7 +456,9 @@ class ClientAuthMessage(AbstractBaseMessage):
         """
         MessageError
         """
-        validate_cookie(_ensure_bytes(payload.get('your_cookie')))
+        payload['your_cookie'] = _ensure_bytes(payload.get('your_cookie'))
+        validate_cookie(payload['your_cookie'])
+        return payload
 
     @property
     def server_cookie(self):
@@ -484,13 +490,15 @@ class ServerAuthMessage(AbstractBaseMessage):
         """
         MessageError
         """
-        validate_cookie(_ensure_bytes(payload.get('your_cookie')))
+        payload['your_cookie'] = _ensure_bytes(payload.get('your_cookie'))
+        validate_cookie(payload['your_cookie'])
         responders = payload.get('responders')
         if responders is not None:
             validate_responder_ids(responders)
         initiator_connected = payload.get('initiator_connected')
         if initiator_connected is not None:
             validate_initiator_connected(responders)
+        return payload
 
     @property
     def client_cookie(self):
@@ -517,7 +525,7 @@ class NewInitiatorMessage(AbstractBaseMessage):
 
     @classmethod
     def check_payload(cls, client, payload):
-        pass
+        return payload
 
 
 class NewResponderMessage(AbstractBaseMessage):
@@ -538,6 +546,7 @@ class NewResponderMessage(AbstractBaseMessage):
         MessageError
         """
         validate_responder_id(payload.get('id'))
+        return payload
 
     @property
     def responder_id(self):
@@ -562,6 +571,7 @@ class DropResponderMessage(AbstractBaseMessage):
         MessageError
         """
         validate_responder_id(payload.get('id'))
+        return payload
 
     @property
     def responder_id(self):
@@ -586,6 +596,7 @@ class SendErrorMessage(AbstractBaseMessage):
         MessageError
         """
         validate_hash(payload.get('hash'))
+        return payload
 
     @property
     def message_hash(self):

--- a/saltyrtc/message.py
+++ b/saltyrtc/message.py
@@ -2,6 +2,7 @@ import abc
 import struct
 import io
 import binascii
+import collections
 
 # noinspection PyPackageRequirements
 import umsgpack
@@ -43,6 +44,21 @@ def unpack(client, data):
     MessageFlowError
     """
     return AbstractBaseMessage.unpack(client, data)
+
+
+def ensurebytes(data):
+    """
+    Convert byte array to byte string. Leave byte strings unmodified.
+
+    TypeError
+    ValueError
+    """
+    if isinstance(data, bytes):
+        return data
+    elif isinstance(data, collections.Iterable):
+        return bytes(data)
+    else:
+        raise TypeError('ensurebytes function expects iterable or bytes')
 
 
 def _message_representation(class_name, nonce, payload, encrypted=None):
@@ -381,11 +397,11 @@ class ServerHelloMessage(AbstractBaseMessage):
         """
         MessageError
         """
-        validate_public_key(payload.get('key'))
+        validate_public_key(ensurebytes(payload.get('key')))
 
     @property
     def server_public_key(self):
-        return self.payload['key']
+        return ensurebytes(self.payload['key'])
 
 
 class ClientHelloMessage(AbstractBaseMessage):
@@ -405,11 +421,11 @@ class ClientHelloMessage(AbstractBaseMessage):
         """
         MessageError
         """
-        validate_public_key(payload.get('key'))
+        validate_public_key(ensurebytes(payload.get('key')))
 
     @property
     def client_public_key(self):
-        return self.payload['key']
+        return ensurebytes(self.payload['key'])
 
 
 class ClientAuthMessage(AbstractBaseMessage):
@@ -429,11 +445,11 @@ class ClientAuthMessage(AbstractBaseMessage):
         """
         MessageError
         """
-        validate_cookie(payload.get('your_cookie'))
+        validate_cookie(ensurebytes(payload.get('your_cookie')))
 
     @property
     def server_cookie(self):
-        return self.payload['your_cookie']
+        return ensurebytes(self.payload['your_cookie'])
 
 
 class ServerAuthMessage(AbstractBaseMessage):
@@ -470,7 +486,7 @@ class ServerAuthMessage(AbstractBaseMessage):
 
     @property
     def client_cookie(self):
-        return self.payload['your_cookie']
+        return ensurebytes(self.payload['your_cookie'])
 
     @property
     def responder_ids(self):


### PR DESCRIPTION
This is a workaround for JavaScript related problems with serializing `TypedArray`s and `ArrayBuffer`s.