### PR TITLE
Add example service file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/saltyrtc-server.service.example
+++ b/saltyrtc-server.service.example
@@ -1,0 +1,19 @@
+[Unit]
+Description=SaltyRTC signaling server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/srv/saltyrtc-server-python/venv/bin/python examples/debug.py
+WorkingDirectory=/srv/saltyrtc-server-python
+Environment=SALTYRTC_TLS_CERT=/path/to/cert.pem
+Environment=SALTYRTC_TLS_KEY=/path/to/key.pem
+User=saltyrtc
+Group=saltyrtc
+Restart=always
+RestartSec=5
+TimeoutStartSec=2
+TimeoutStopSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Example service file for systemd.

Maybe we should create a single `server.py` entry point instead of keeping multiple scripts in the `examples` directory...