### PR TITLE
Make TLS optional

### DIFF
--- a/examples/debug.py
+++ b/examples/debug.py
@@ -26,10 +26,13 @@ def main():
     loop = asyncio.get_event_loop()
 
     # Create SSL context
-    ssl_context = saltyrtc.util.create_ssl_context(
-        certfile=require_env('SALTYRTC_TLS_CERT'),
-        keyfile=require_env('SALTYRTC_TLS_KEY'),
-    )
+    if env('SALTYRTC_DISABLE_TLS') != 'yes-and-i-know-what-im-doing':
+        ssl_context = saltyrtc.util.create_ssl_context(
+            certfile=require_env('SALTYRTC_TLS_CERT'),
+            keyfile=require_env('SALTYRTC_TLS_KEY'),
+        )
+    else:
+        ssl_context = None
 
     # Start server
     coroutine = saltyrtc.serve(ssl_context, port=int(env('SALTYRTC_PORT', '8765')))

--- a/examples/nginx.conf.example
+++ b/examples/nginx.conf.example
@@ -1,0 +1,42 @@
+# Nginx example configuration as a WebSocket proxy with TLS termination.
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+upstream websocket {
+    server 127.0.0.1:8765;
+}
+
+server {
+    listen 80 default_server;
+    listen 443 default_server;
+    listen [::]:80 default_server;
+    listen [::]:443 default_server;
+    server_name _;
+    return 444;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name saltyrtc.example.com;
+
+    # TLS
+    add_header Strict-Transport-Security max-age=2592000;
+    ssl_certificate /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    # Logging
+    access_log /var/log/nginx/saltyrtc.example.com.access.log;
+    error_log /var/log/nginx/saltyrtc.example.com.error.log error;
+
+    location / {
+        proxy_pass http://websocket;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_read_timeout 60s;
+    }
+}


### PR DESCRIPTION
This should only be used when doing TLS termination in a proxy server, e.g. Nginx.

We could also provide an nginx example configuration.