### PR TITLE
Adapt codebase to breaking libnacl changes

### DIFF
--- a/saltyrtc/server/message.py
+++ b/saltyrtc/server/message.py
@@ -4,6 +4,7 @@ import io
 import struct
 
 # noinspection PyPackageRequirements
+import libnacl
 import umsgpack
 
 from .common import sign_keys as sign_keys_
@@ -374,14 +375,14 @@ class AbstractBaseMessage(AbstractMessage, metaclass=abc.ABCMeta):
         try:
             _, data = client.box.encrypt(payload, nonce=nonce, pack_nonce=False)
             return data
-        except ValueError as exc:
+        except (ValueError, libnacl.CryptError) as exc:
             raise MessageError('Could not encrypt payload') from exc
 
     @classmethod
     def _decrypt_payload(cls, client, nonce, data):
         try:
             return client.box.decrypt(data, nonce=nonce)
-        except ValueError as exc:
+        except (ValueError, libnacl.CryptError) as exc:
             raise MessageError('Could not decrypt payload') from exc
 
 

--- a/saltyrtc/server/server.py
+++ b/saltyrtc/server/server.py
@@ -1,7 +1,6 @@
 import asyncio
 import binascii
 import inspect
-
 from collections import OrderedDict
 from typing import (
     Dict,

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     version=get_version(),
     packages=['saltyrtc', 'saltyrtc.server'],
     install_requires=[
-        'libnacl>=1.5.0,<=1.5.2',  # doesn't seem to follow semantic versioning
+        'libnacl>=1.5.0,<2',
         'click>=6.7',  # doesn't seem to follow semantic versioning (see #57)
         'websockets>=3.2,<4',
         'u-msgpack-python>=2.3,<3',

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ setup(
     version=get_version(),
     packages=['saltyrtc', 'saltyrtc.server'],
     install_requires=[
-        'libnacl>=1.5.0,<2',
-        'click>=6.7',  # doesn't seem to follow semantic versioning
+        'libnacl>=1.5.0,<=1.5.2',  # doesn't seem to follow semantic versioning
+        'click>=6.7',  # doesn't seem to follow semantic versioning (see #57)
         'websockets>=3.2,<4',
         'u-msgpack-python>=2.3,<3',
     ],

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
             'asyncio>=3.4.3',
             'typing>=3,<4',
             'backports_abc==0.5',
+            'pytest-asyncio==0.5.0',
         ],
         'dev': tests_require,
         'logging': logging_require,


### PR DESCRIPTION
The libnacl library changed its exceptions API in a patch release. Therefore we need to pin the dependency to a specific release.

We should also release a patch release for saltyrtc-server with this fix soon.

Refs https://github.com/saltstack/libnacl/pull/98