### PR TITLE
Adjust log message when waiting for client-hello or client-auth

### DIFF
--- a/saltyrtc/server/server.py
+++ b/saltyrtc/server/server.py
@@ -344,7 +344,7 @@ class ServerProtocol(Protocol):
         yield from client.send(message)
 
         # Receive client-hello or client-auth
-        client.log.debug('Waiting for client-hello')
+        client.log.debug('Waiting for client-hello or client-auth')
         message = yield from client.receive()
         if message.type == MessageType.client_auth:
             client.log.debug('Received client-auth')


### PR DESCRIPTION
The old one confused me a bit when implementing the new client.