### PR TITLE
Fix invalid order of messages & invalid send-error ID

### DIFF
--- a/saltyrtc/server/protocol.py
+++ b/saltyrtc/server/protocol.py
@@ -8,6 +8,7 @@ import websockets
 
 from . import util
 from .common import (
+    COOKIE_LENGTH,
     KEEP_ALIVE_INTERVAL_DEFAULT,
     KEEP_ALIVE_INTERVAL_MIN,
     KEEP_ALIVE_TIMEOUT,
@@ -331,7 +332,7 @@ class PathClient:
         Return the cookie of the server (outgoing messages).
         """
         if self._cookie_out is None:
-            self._cookie_out = os.urandom(16)
+            self._cookie_out = os.urandom(COOKIE_LENGTH)
         return self._cookie_out
 
     @property

--- a/saltyrtc/server/server.py
+++ b/saltyrtc/server/server.py
@@ -11,6 +11,8 @@ import websockets
 
 from . import util
 from .common import (
+    COOKIE_LENGTH,
+    NONCE_LENGTH,
     RELAY_TIMEOUT,
     AddressType,
     CloseCode,
@@ -543,7 +545,7 @@ class ServerProtocol(Protocol):
 
         # Prepare message
         source.log.debug('Packing relay message')
-        message_id = message.pack(source)[16:]
+        message_id = message.pack(source)[COOKIE_LENGTH:NONCE_LENGTH]
 
         @asyncio.coroutine
         def send_error_message():

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ tests_require = [
     'isort>=4.2.5',
     'collective.checkdocs>=0.2',
     'Pygments>=2.2.0',  # required by checkdocs
+    'ordered-set>=3.0.0',  # required by TestServer class
 ] + logging_require
 
 setup(

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1036,7 +1036,8 @@ class TestProtocol:
         assert sck == i['sck']
         assert scsn == i['start_scsn'] + 2
         assert message['type'] == 'send-error'
-        assert message['id'] == data[16:]
+        assert len(message['id']) == 8
+        assert message['id'] == data[16:24]
 
         # Send relay message to an invalid destination
         yield from initiator.send(pack_nonce(i['rcck'], i['id'], 0x01, i['rccsn']), {
@@ -1195,7 +1196,8 @@ class TestProtocol:
         assert sck == i['sck']
         assert scsn == i['start_scsn'] + 2
         assert message['type'] == 'send-error'
-        assert message['id'] == data[16:]
+        assert len(message['id']) == 8
+        assert message['id'] == data[16:24]
 
         # Bye
         yield from initiator.close()


### PR DESCRIPTION
Until now, a `disconnected` message slipped in before the `send-error` message has been sent.
Furthermore, an invalid message ID has been sent in the `send-error` message (which we will likely remove anyway).

Resolves #77