### PR TITLE
Rename --ssl(cert|key) options to --tls(cert|key)

### DIFF
--- a/saltyrtc/server/bin.py
+++ b/saltyrtc/server/bin.py
@@ -32,6 +32,10 @@ __all__ = (
 )
 
 
+def _echo_deprecated(message: str) -> None:
+    click.echo(click.style('DeprecationWarning: {}'.format(message), fg='yellow'))
+
+
 def _h(text: str) -> str:
     """
     For some reason, :mod:`click` does not strip new line characters
@@ -165,14 +169,21 @@ provided will be used as the primary key."""))
 @click.pass_context
 def serve(ctx: click.Context, **arguments: Any) -> None:
     # Get arguments
-    tls_cert = arguments.get('tlscert', None) or arguments.get('sslcert', None)  # type: Optional[str]
-    tls_key = arguments.get('tlskey', None) or arguments.get('sslkey', None)  # type: Optional[str]
+    ssl_cert = arguments.get('sslcert', None)  # type: Optional[str]
+    ssl_key = arguments.get('sslkey', None)  # type: Optional[str]
+    tls_cert = arguments.get('tlscert', None) or ssl_cert  # type: Optional[str]
+    tls_key = arguments.get('tlskey', None) or ssl_key  # type: Optional[str]
     dh_params = arguments.get('dhparams', None)  # type: Optional[str]
     keys_str = arguments['key']  # type: Sequence[str]
     host = arguments.get('host')  # type: Optional[str]
     port = arguments['port']  # type: int
     loop_str = arguments['loop']  # type: str
     safety_off = os.environ.get('SALTYRTC_SAFETY_OFF') == 'yes-and-i-know-what-im-doing'
+
+    # Deprecation warning
+    if ssl_cert is not None or ssl_key is not None:
+        _echo_deprecated(('The options -sc, --sslcert and -sk, --sslkey are deprecated. '
+                          'Use -tc, --tlscert and -tk, --tlskey instead.'))
 
     # Make sure the user provides cert & keys or has safety turned off
     if tls_cert is None or len(keys_str) == 0:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,8 +84,8 @@ class TestCLI:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
                 'serve',
-                '-sc', pytest.saltyrtc.cert,
-                '-sk', pytest.saltyrtc.key,
+                '-tc', pytest.saltyrtc.cert,
+                '-tk', pytest.saltyrtc.key,
                 '-p', '8443',
             )
         assert 'It is REQUIRED' in exc_info.value.output
@@ -97,7 +97,7 @@ class TestCLI:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
                 'serve',
-                '-sc', str(cert),
+                '-tc', str(cert),
                 '-k', pytest.saltyrtc.permanent_key_primary,
                 '-p', '8443',
             )
@@ -110,8 +110,8 @@ class TestCLI:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
                 'serve',
-                '-sc', pytest.saltyrtc.cert,
-                '-sk', pytest.saltyrtc.key,
+                '-tc', pytest.saltyrtc.cert,
+                '-tk', pytest.saltyrtc.key,
                 '-k', str(keyfile),
                 '-p', '8443',
             )
@@ -124,8 +124,8 @@ class TestCLI:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
                 'serve',
-                '-sc', pytest.saltyrtc.cert,
-                '-sk', pytest.saltyrtc.key,
+                '-tc', pytest.saltyrtc.cert,
+                '-tk', pytest.saltyrtc.key,
                 '-k', pytest.saltyrtc.permanent_key_primary,
                 '-dhp', str(dh_params_file),
                 '-p', '8443',
@@ -138,8 +138,8 @@ class TestCLI:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
                 'serve',
-                '-sc', pytest.saltyrtc.cert,
-                '-sk', pytest.saltyrtc.key,
+                '-tc', pytest.saltyrtc.cert,
+                '-tk', pytest.saltyrtc.key,
                 '-k', key,
                 '-p', '8443',
             )
@@ -150,8 +150,8 @@ class TestCLI:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
                 'serve',
-                '-sc', pytest.saltyrtc.cert,
-                '-sk', pytest.saltyrtc.key,
+                '-tc', pytest.saltyrtc.cert,
+                '-tk', pytest.saltyrtc.key,
                 '-k', pytest.saltyrtc.permanent_key_primary,
                 '-h', 'meow',
                 '-p', '8443',
@@ -163,8 +163,8 @@ class TestCLI:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
                 'serve',
-                '-sc', pytest.saltyrtc.cert,
-                '-sk', pytest.saltyrtc.key,
+                '-tc', pytest.saltyrtc.cert,
+                '-tk', pytest.saltyrtc.key,
                 '-k', pytest.saltyrtc.permanent_key_primary,
                 '-p', 'meow',
             )
@@ -175,8 +175,8 @@ class TestCLI:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
                 'serve',
-                '-sc', pytest.saltyrtc.cert,
-                '-sk', pytest.saltyrtc.key,
+                '-tc', pytest.saltyrtc.cert,
+                '-tk', pytest.saltyrtc.key,
                 '-k', pytest.saltyrtc.permanent_key_primary,
                 '-p', '8443',
                 '-l', 'meow',
@@ -189,8 +189,8 @@ class TestCLI:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
                 'serve',
-                '-sc', pytest.saltyrtc.cert,
-                '-sk', pytest.saltyrtc.key,
+                '-tc', pytest.saltyrtc.cert,
+                '-tk', pytest.saltyrtc.key,
                 '-k', pytest.saltyrtc.permanent_key_primary,
                 '-p', '8443',
                 '-l', 'uvloop',
@@ -201,8 +201,8 @@ class TestCLI:
     async def test_serve_asyncio(self, cli):
         output = await cli(
             'serve',
-            '-sc', pytest.saltyrtc.cert,
-            '-sk', pytest.saltyrtc.key,
+            '-tc', pytest.saltyrtc.cert,
+            '-tk', pytest.saltyrtc.key,
             '-k', pytest.saltyrtc.permanent_key_primary,
             '-p', '8443',
             signal=signal.SIGINT,
@@ -213,8 +213,8 @@ class TestCLI:
     async def test_serve_asyncio_dh_params(self, cli):
         output = await cli(
             'serve',
-            '-sc', pytest.saltyrtc.cert,
-            '-sk', pytest.saltyrtc.key,
+            '-tc', pytest.saltyrtc.cert,
+            '-tk', pytest.saltyrtc.key,
             '-k', pytest.saltyrtc.permanent_key_primary,
             '-dhp', pytest.saltyrtc.dh_params,
             '-p', '8443',
@@ -226,8 +226,8 @@ class TestCLI:
     async def test_serve_asyncio_hex_encoded_key(self, cli):
         output = await cli(
             'serve',
-            '-sc', pytest.saltyrtc.cert,
-            '-sk', pytest.saltyrtc.key,
+            '-tc', pytest.saltyrtc.cert,
+            '-tk', pytest.saltyrtc.key,
             '-k', open(pytest.saltyrtc.permanent_key_primary, 'r').read(),
             '-p', '8443',
             signal=signal.SIGINT,
@@ -239,8 +239,8 @@ class TestCLI:
         output = await cli(
             '-v', '7',
             'serve',
-            '-sc', pytest.saltyrtc.cert,
-            '-sk', pytest.saltyrtc.key,
+            '-tc', pytest.saltyrtc.cert,
+            '-tk', pytest.saltyrtc.key,
             '-k', pytest.saltyrtc.permanent_key_primary,
             '-p', '8443',
             signal=signal.SIGINT,
@@ -253,8 +253,8 @@ class TestCLI:
     async def test_serve_uvloop(self, cli):
         output = await cli(
             'serve',
-            '-sc', pytest.saltyrtc.cert,
-            '-sk', pytest.saltyrtc.key,
+            '-tc', pytest.saltyrtc.cert,
+            '-tk', pytest.saltyrtc.key,
             '-k', pytest.saltyrtc.permanent_key_primary,
             '-p', '8443',
             '-l', 'uvloop',
@@ -267,8 +267,8 @@ class TestCLI:
     async def test_serve_uvloop_dh_params(self, cli):
         output = await cli(
             'serve',
-            '-sc', pytest.saltyrtc.cert,
-            '-sk', pytest.saltyrtc.key,
+            '-tc', pytest.saltyrtc.cert,
+            '-tk', pytest.saltyrtc.key,
             '-k', pytest.saltyrtc.permanent_key_primary,
             '-dhp', pytest.saltyrtc.dh_params,
             '-p', '8443',
@@ -283,8 +283,8 @@ class TestCLI:
         output = await cli(
             '-v', '7',
             'serve',
-            '-sc', pytest.saltyrtc.cert,
-            '-sk', pytest.saltyrtc.key,
+            '-tc', pytest.saltyrtc.cert,
+            '-tk', pytest.saltyrtc.key,
             '-k', pytest.saltyrtc.permanent_key_primary,
             '-p', '8443',
             '-l', 'uvloop',
@@ -297,8 +297,8 @@ class TestCLI:
     async def test_serve_asyncio_restart(self, cli):
         output = await cli(
             'serve',
-            '-sc', pytest.saltyrtc.cert,
-            '-sk', pytest.saltyrtc.key,
+            '-tc', pytest.saltyrtc.cert,
+            '-tk', pytest.saltyrtc.key,
             '-k', pytest.saltyrtc.permanent_key_primary,
             '-p', '8443',
             signal=[signal.SIGHUP, signal.SIGINT],
@@ -347,8 +347,8 @@ class TestCLI:
             with pytest.raises(subprocess.CalledProcessError) as exc_info:
                 await cli(*[
                     'serve',
-                    '-sc', pytest.saltyrtc.cert,
-                    '-sk', pytest.saltyrtc.key,
+                    '-tc', pytest.saltyrtc.cert,
+                    '-tk', pytest.saltyrtc.key,
                     '-p', '8443',
                 ] + key_arguments)
             assert 'key has been supplied more than once' in exc_info.value.output
@@ -360,8 +360,8 @@ class TestCLI:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
                 'serve',
-                '-sc', pytest.saltyrtc.cert,
-                '-sk', pytest.saltyrtc.key,
+                '-tc', pytest.saltyrtc.cert,
+                '-tk', pytest.saltyrtc.key,
                 '-k', pytest.saltyrtc.permanent_key_primary,
                 '-k', str(keyfile),
                 '-p', '8443',
@@ -374,8 +374,8 @@ class TestCLI:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
                 'serve',
-                '-sc', pytest.saltyrtc.cert,
-                '-sk', pytest.saltyrtc.key,
+                '-tc', pytest.saltyrtc.cert,
+                '-tk', pytest.saltyrtc.key,
                 '-k', pytest.saltyrtc.permanent_key_primary,
                 '-k', key,
                 '-p', '8443',
@@ -393,8 +393,8 @@ class TestCLI:
         # Check output
         output = await cli(
             'serve',
-            '-sc', pytest.saltyrtc.cert,
-            '-sk', pytest.saltyrtc.key,
+            '-tc', pytest.saltyrtc.cert,
+            '-tk', pytest.saltyrtc.key,
             '-k', pytest.saltyrtc.permanent_key_primary,
             '-k', pytest.saltyrtc.permanent_key_secondary,
             '-p', '8443',
@@ -415,8 +415,8 @@ class TestCLI:
         # Check output
         output = await cli(
             'serve',
-            '-sc', pytest.saltyrtc.cert,
-            '-sk', pytest.saltyrtc.key,
+            '-tc', pytest.saltyrtc.cert,
+            '-tk', pytest.saltyrtc.key,
             '-k', pytest.saltyrtc.permanent_key_secondary,
             '-k', pytest.saltyrtc.permanent_key_primary,
             '-p', '8443',
@@ -424,4 +424,17 @@ class TestCLI:
         )
         assert 'Primary public permanent key: {}'.format(secondary_key) in output
         assert 'Secondary key #1: {}'.format(primary_key) in output
+        assert 'Stopped' in output
+
+    @pytest.mark.asyncio
+    async def test_serve_deprecated_options(self, cli):
+        output = await cli(
+            'serve',
+            '-sc', pytest.saltyrtc.cert,
+            '-sk', pytest.saltyrtc.key,
+            '-k', pytest.saltyrtc.permanent_key_primary,
+            '-p', '8443',
+            signal=signal.SIGINT,
+        )
+        assert 'DeprecationWarning' in output
         assert 'Stopped' in output


### PR DESCRIPTION
The old arguments still exist, but are marked as deprecated.

Fixes #63.

@lgrahl do you know whether the deprecated command line arguments can be hidden?

Do we need a deprecation warning when still using the old commands?