### PR TITLE
Require Python >= 3.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ before_cache:
 language: python
 matrix:
   include:
-  - python: "3.5"
+  - python: "3.5.3"
     env:
     - EVENT_LOOP=asyncio
     - TIMEOUT=2.0
-  - python: "3.5"
+  - python: "3.5.3"
     env:
     - EVENT_LOOP=uvloop
     - TIMEOUT=2.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 `4.0.0`_ (2018-01-24)
 ---------------------
 
-**Important:** Make sure you're using Python >= 3.5.2 before upgrading.
+**Important:** Make sure you're using Python >= 3.5.3 before upgrading.
 
 - Drop Python 3.4 support (major)
 - Deprecate the CLI options `-sc`, `--sslcert` and `-sk`, `--sslkey`. Use

--- a/examples/debug.py
+++ b/examples/debug.py
@@ -3,13 +3,13 @@ import os
 import ssl  # noqa
 import sys
 from typing import Any  # noqa
+from typing import Coroutine  # noqa
 from typing import List  # noqa
 from typing import Optional
 
 import logbook.more
 
 import saltyrtc.server
-from saltyrtc.server.typing import Coroutine  # noqa
 from saltyrtc.server.typing import ServerSecretPermanentKey  # noqa
 
 

--- a/examples/restartable.py
+++ b/examples/restartable.py
@@ -4,13 +4,13 @@ import signal
 import ssl  # noqa
 import sys
 from typing import Any  # noqa
+from typing import Coroutine  # noqa
 from typing import List  # noqa
 from typing import Optional
 
 import logbook.more
 
 import saltyrtc.server
-from saltyrtc.server.typing import Coroutine  # noqa
 from saltyrtc.server.typing import ServerSecretPermanentKey  # noqa
 
 

--- a/saltyrtc/server/__init__.py
+++ b/saltyrtc/server/__init__.py
@@ -1,5 +1,5 @@
 """
-This is a SaltyRTC server implementation for Python 3.5+ using
+This is a SaltyRTC server implementation for Python 3.5.3+ using
 :mod:`asyncio`.
 """
 import itertools

--- a/saltyrtc/server/bin.py
+++ b/saltyrtc/server/bin.py
@@ -7,6 +7,7 @@ import os
 import signal
 import stat
 from typing import Any  # noqa
+from typing import Coroutine  # noqa
 from typing import List  # noqa
 from typing import Optional  # noqa
 from typing import Sequence  # noqa
@@ -19,7 +20,6 @@ from . import (
     server,
     util,
 )
-from .typing import Coroutine  # noqa
 from .typing import ServerSecretPermanentKey  # noqa
 from .typing import LogbookLevel
 

--- a/saltyrtc/server/message.py
+++ b/saltyrtc/server/message.py
@@ -2,6 +2,7 @@ import abc
 import binascii
 import io
 import struct
+from typing import ClassVar  # noqa
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -42,7 +43,6 @@ from .exception import (
     MessageError,
     MessageFlowError,
 )
-from .typing import ClassVar  # noqa
 from .typing import (
     ChosenSubProtocol,
     ClientCookie,

--- a/saltyrtc/server/protocol.py
+++ b/saltyrtc/server/protocol.py
@@ -2,6 +2,8 @@ import asyncio
 import enum
 import os
 import struct
+# noinspection PyUnresolvedReferences
+from typing import Coroutine  # noqa
 from typing import Dict  # noqa
 from typing import (
     Any,
@@ -47,8 +49,6 @@ from .message import (
     OutgoingMessageMixin,
     unpack,
 )
-# noinspection PyUnresolvedReferences
-from .typing import Coroutine  # noqa
 from .typing import (
     ClientCookie,
     ClientPublicKey,

--- a/saltyrtc/server/server.py
+++ b/saltyrtc/server/server.py
@@ -3,11 +3,13 @@ import binascii
 import ssl
 from collections import OrderedDict
 from typing import Awaitable  # noqa
+from typing import ClassVar  # noqa
 from typing import Dict  # noqa
 from typing import List  # noqa
 from typing import Set  # noqa
 from typing import (
     Any,
+    Coroutine,
     Iterable,
     Mapping,
     Optional,
@@ -67,10 +69,8 @@ from .protocol import (
     Path,
     PathClient,
 )
-from .typing import ClassVar  # noqa
 from .typing import (
     ChosenSubProtocol,
-    Coroutine,
     DisconnectedData,
     EventCallback,
     EventData,

--- a/saltyrtc/server/typing.py
+++ b/saltyrtc/server/typing.py
@@ -1,4 +1,3 @@
-import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -24,8 +23,6 @@ if TYPE_CHECKING:
     from .events import Event  # noqa
 
 __all__ = (
-    'Coroutine',
-    'ClassVar',
     'NoReturn',
     'ListOrTuple',
     'PathHex',
@@ -62,20 +59,6 @@ __all__ = (
 # Important: Do not export!
 T = TypeVar('T')  # Any type
 
-# Coroutine
-try:
-    from typing import Coroutine
-except ImportError:
-    # noinspection PyUnresolvedReferences
-    from typing_extensions import Coroutine  # Python <= 3.5.2
-
-# ClassVar
-try:
-    from typing import ClassVar
-except ImportError:
-    # noinspection PyUnresolvedReferences
-    from typing_extensions import ClassVar  # Python <= 3.5.2
-
 # NoReturn
 try:
     from typing import NoReturn
@@ -87,12 +70,7 @@ except ImportError:
 # -------
 
 # List or Tuple
-py_version = sys.version_info[:3]
-if py_version > (3, 5, 2):
-    ListOrTuple = Union[List[T], Tuple[T]]
-else:
-    # Workaround for "Cannot subscript an existing Union" in Python 3.5.2
-    ListOrTuple = List  # type: ignore
+ListOrTuple = Union[List[T], Tuple[T]]
 
 
 # Common

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ long_description = '\n\n'.join((read('README.rst'), read('CHANGELOG.rst')))
 
 # Check python version
 py_version = sys.version_info[:3]
-if py_version < (3, 5, 2):
-    raise Exception("SaltyRTC requires Python >= 3.5.2")
+if py_version < (3, 5, 3):
+    raise Exception("SaltyRTC requires Python >= 3.5.3")
 
 # Logging requirements
 logging_require = [
@@ -73,9 +73,6 @@ setup(
     ],
     tests_require=tests_require,
     extras_require={
-        ':python_version<="3.5.2"': [
-            'typing-extensions==3.7.2',
-        ],
         'dev': tests_require,
         'logging': logging_require,
         'uvloop': ['uvloop>=0.8.0,<2'],


### PR DESCRIPTION
Python 3.5.2's `typing` module is utterly broken which unfortunately results in runtime errors:

```python
import asyncio
from typing import *
Optional['asyncio.Task[None]']
```

Output:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.5/typing.py", line 649, in __getitem__
    return Union[arg, type(None)]
  File "/usr/lib/python3.5/typing.py", line 552, in __getitem__
    dict(self.__dict__), parameters, _root=True)
  File "/usr/lib/python3.5/typing.py", line 512, in __new__
    for t2 in all_params - {t1} if not isinstance(t2, TypeVar)):
  File "/usr/lib/python3.5/typing.py", line 512, in <genexpr>
    for t2 in all_params - {t1} if not isinstance(t2, TypeVar)):
  File "/usr/lib/python3.5/typing.py", line 190, in __subclasscheck__
    self._eval_type(globalns, localns)
  File "/usr/lib/python3.5/typing.py", line 177, in _eval_type
    eval(self.__forward_code__, globalns, localns),
  File "<string>", line 1, in <module>
TypeError: 'type' object is not subscriptable
```