### PR TITLE
Fix tagged builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,9 @@ jobs:
     environment:
       - SUPPORTED_TAGS: ^v4\.[1-9]+\.[0-9]+$
     steps:
+      - run:
+          name: Install git
+          command: apk add git
       - checkout
       - setup_remote_docker
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
     steps:
       - run:
           name: Install git
-          command: apk add git
+          command: apk add git openssh
       - checkout
       - setup_remote_docker
       - run:


### PR DESCRIPTION
CircleCI uses an outdated `git` version by default which can't checkout annotated tags.