### PR TITLE
Yet another task queue refactoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,22 +76,6 @@ jobs:
       - EVENT_LOOP: uvloop
       - TIMEOUT: "2.0"
 
-  test-pypy-3_6-asyncio:
-    <<: *shared
-    docker:
-      - image: saltyrtc/circleci-image-python:pypy-3.6
-    environment:
-      - EVENT_LOOP: asyncio
-      - TIMEOUT: "6.0"
-
-  test-pypy-3_5-asyncio:
-    <<: *shared
-    docker:
-      - image: saltyrtc/circleci-image-python:pypy-3.5
-    environment:
-      - EVENT_LOOP: asyncio
-      - TIMEOUT: "6.0"
-
   lint:
     docker:
       - image: saltyrtc/circleci-image-python:python-3.7
@@ -178,8 +162,6 @@ workflows:
       - test-python-3_6-uvloop
       - test-python-3_5-asyncio
       - test-python-3_5-uvloop
-      - test-pypy-3_6-asyncio
-      - test-pypy-3_5-asyncio
   docker:
     jobs:
       - build-docker:

--- a/saltyrtc/server/__init__.py
+++ b/saltyrtc/server/__init__.py
@@ -10,6 +10,7 @@ from .exception import *  # noqa
 from .message import *  # noqa
 from .protocol import *  # noqa
 from .server import *  # noqa
+from .task import *  # noqa
 from .util import *  # noqa
 
 __all__ = tuple(itertools.chain(
@@ -20,6 +21,7 @@ __all__ = tuple(itertools.chain(
     message.__all__,  # noqa
     protocol.__all__,  # noqa
     server.__all__,  # noqa
+    task.__all__,  # noqa
     util.__all__,  # noqa
 ))
 

--- a/saltyrtc/server/bin.py
+++ b/saltyrtc/server/bin.py
@@ -6,11 +6,11 @@ import enum
 import os
 import signal
 import stat
-from typing import Any  # noqa
 from typing import Coroutine  # noqa
 from typing import List  # noqa
 from typing import Optional  # noqa
 from typing import Sequence  # noqa
+from typing import Any
 
 import click
 import libnacl.public

--- a/saltyrtc/server/common.py
+++ b/saltyrtc/server/common.py
@@ -32,7 +32,6 @@ __all__ = (
     'KEEP_ALIVE_INTERVAL_DEFAULT',
     'KEEP_ALIVE_TIMEOUT',
     'OverflowSentinel',
-    'TaskLoopStopSentinel',
     'SubProtocol',
     'CloseCode',
     'DropReason',
@@ -74,13 +73,6 @@ class OverflowSentinel:
     """
     The combined sequence number will be set to this object if the
     counter did overflow.
-    """
-
-
-class TaskLoopStopSentinel:
-    """
-    The task loop will stop if this has been dequeued from the task
-    queue.
     """
 
 

--- a/saltyrtc/server/exception.py
+++ b/saltyrtc/server/exception.py
@@ -86,7 +86,7 @@ class DowngradeError(SignalingError):
 class Disconnected(Exception):
     """
     The client disconnected from the server or has been disconnected by
-    the server.
+    the server (e.g. by a drop request).
 
     ..note:: This does not derive from :class:`SignalingError` since it
              is not considered an *error*.

--- a/saltyrtc/server/protocol.py
+++ b/saltyrtc/server/protocol.py
@@ -267,7 +267,7 @@ class PathClientTasks:
         self.task_loop = None  # type: Optional[asyncio.Task[None]]
         self.receive_loop = None  # type: Optional[asyncio.Task[None]]
         self.keep_alive_loop = None  # type: Optional[asyncio.Task[None]]
-        self.active_task = None  # type: Optional[asyncio.Future[None]]
+        self.active_task = None  # type: Optional[Task]
 
     @property
     def tasks(self) -> Sequence[Optional['asyncio.Task[None]']]:
@@ -812,9 +812,10 @@ class PathClient:
 
     def stop_task_queue(self, immediate: bool = False) -> None:
         """
-        Stop the task queue looper.
+        Ask the task queue looper to stop eventually.
         """
-        if self.tasks.task_loop is not None and not self.tasks.task_loop.done():
+        if (self.tasks.active_task is not None and
+                self.tasks.active_task is not TaskLoopStopSentinel):
             if immediate:
                 self._task_queue.put_nowait(TaskLoopStopSentinel)
             else:

--- a/saltyrtc/server/protocol.py
+++ b/saltyrtc/server/protocol.py
@@ -688,6 +688,7 @@ class PathClient:
         """
         Disconnected
         """
+        self.log.debug('Waiting for pong')
         try:
             await pong_future
         except websockets.ConnectionClosed as exc:

--- a/saltyrtc/server/protocol.py
+++ b/saltyrtc/server/protocol.py
@@ -2,7 +2,6 @@ import asyncio
 import os
 import struct
 # noinspection PyUnresolvedReferences
-from typing import Coroutine  # noqa
 from typing import Dict  # noqa
 from typing import (
     Any,
@@ -47,7 +46,6 @@ from .message import (
     unpack,
 )
 from .task import (
-    FinalJob,
     JobQueue,
     Tasks,
 )

--- a/saltyrtc/server/protocol.py
+++ b/saltyrtc/server/protocol.py
@@ -6,7 +6,6 @@ from typing import Coroutine  # noqa
 from typing import Dict  # noqa
 from typing import (
     Any,
-    Awaitable,
     Iterable,
     Optional,
     Type,
@@ -672,7 +671,7 @@ class PathClient:
         self.log.trace('server << {}', message)
         return message
 
-    async def ping(self) -> Awaitable[None]:
+    async def ping(self) -> 'asyncio.Future[None]':
         """
         Disconnected
         """
@@ -683,9 +682,9 @@ class PathClient:
             self.log.debug('Connection closed while pinging')
             self.jobs.close()
             raise Disconnected(exc.code) from exc
-        return self._wait_pong(pong_future)
+        return cast('asyncio.Future[None]', pong_future)
 
-    async def _wait_pong(self, pong_future: 'asyncio.Future[None]') -> None:
+    async def wait_pong(self, pong_future: 'asyncio.Future[None]') -> None:
         """
         Disconnected
         """

--- a/saltyrtc/server/server.py
+++ b/saltyrtc/server/server.py
@@ -740,7 +740,11 @@ class ServerProtocol:
             log_message = 'Sending relayed message to 0x{:02x} timed out'
             source.log.info(log_message, destination_id)
             await send_error_message()
-        except Exception:
+        except Exception as exc:
+            # Handle cancellation of the client
+            if isinstance(exc, asyncio.CancelledError) and source.tasks.have_result:
+                raise
+
             # An exception has been triggered while sending the message.
             # Note: We don't care about the actual exception as the job
             #       queue runner will also trigger that exception on the

--- a/saltyrtc/server/server.py
+++ b/saltyrtc/server/server.py
@@ -759,7 +759,8 @@ class ServerProtocol:
             pong_future = await client.ping()
             try:
                 await asyncio.wait_for(
-                    pong_future, client.keep_alive_timeout, loop=self._loop)
+                    client.wait_pong(pong_future), client.keep_alive_timeout,
+                    loop=self._loop)
             except asyncio.TimeoutError:
                 client.log.debug('Ping timed out')
                 raise PingTimeoutError(str(client))

--- a/saltyrtc/server/server.py
+++ b/saltyrtc/server/server.py
@@ -392,7 +392,12 @@ class ServerProtocol:
         if self.client is not None:
             # We need to use 'drop' in order to prevent the server from sending a
             # 'disconnect' message for each client.
-            self._drop_client(self.client, code)
+            try:
+                self._drop_client(self.client, code)
+            except KeyError:
+                # We can safely ignore this since clients will be removed immediately
+                # from the path in case they are being dropped by another client.
+                pass
 
     def get_path_client(
             self,

--- a/saltyrtc/server/server.py
+++ b/saltyrtc/server/server.py
@@ -36,7 +36,6 @@ from .common import (
     CloseCode,
     ResponderAddress,
     SubProtocol,
-    TaskLoopStopSentinel,
 )
 from .events import (
     Event,
@@ -78,8 +77,10 @@ from .typing import (
     InitiatorPublicPermanentKey,
     ListOrTuple,
     MessageId,
+    NoReturn,
     PathHex,
     ResponderPublicSessionKey,
+    Result,
     ServerCookie,
     ServerPublicPermanentKey,
     ServerSecretPermanentKey,
@@ -93,7 +94,7 @@ __all__ = (
 )
 
 # Constants
-_TASK_QUEUE_JOIN_TIMEOUT = 10.0
+_JOB_QUEUE_JOIN_TIMEOUT = 10.0
 
 # Do not export!
 ST = TypeVar('ST', bound='Server')
@@ -252,7 +253,6 @@ class ServerProtocol:
         # Handle client until disconnected or an exception occurred
         hex_path = PathHex(binascii.hexlify(path.initiator_key).decode('ascii'))
         close_future = asyncio.Future(loop=self._loop)  # type: asyncio.Future[None]
-
         try:
             await self.handle_client()
         except Disconnected as exc:
@@ -298,22 +298,24 @@ class ServerProtocol:
             close_awaitable = close_future
 
         # Schedule closing of the client
-        # Note: This ensures the client is closed soon even if the task queue is holding
+        # Note: This ensures the client is closed soon even if the job queue is holding
         #       us up.
         if not isinstance(close_awaitable, asyncio.Future):
             close_awaitable = self._loop.create_task(close_awaitable)
 
-        # Wait until all queued tasks have been processed and the task loop returned.
+        # Wait until all queued jobs have been processed and the job queue runner
+        # returned.
+        #
         # Note: This ensure that a send-error message (and potentially other messages)
         #       are enqueued towards other clients before the disconnect message.
         try:
             await asyncio.wait_for(
-                client.join_task_queue(), _TASK_QUEUE_JOIN_TIMEOUT, loop=self._loop)
+                client.jobs.join(), _JOB_QUEUE_JOIN_TIMEOUT, loop=self._loop)
         except asyncio.TimeoutError:
             client.log.error(
-                'Task queue did not complete after {} seconds', _TASK_QUEUE_JOIN_TIMEOUT)
+                'Job queue did not complete within {} seconds', _JOB_QUEUE_JOIN_TIMEOUT)
         else:
-            client.log.debug('Task queue completed')
+            client.log.debug('Job queue completed')
 
         # Send disconnected message if client was authenticated
         if client.state == ClientState.authenticated:
@@ -324,11 +326,11 @@ class ServerProtocol:
                 for responder_id in responder_ids:
                     responder = path.get_responder(responder_id)
 
-                    # Create message and add send coroutine to task queue of the responder
+                    # Create message and add send coroutine to job queue of the responder
                     message = DisconnectedMessage.create(
                         responder_id, INITIATOR_ADDRESS)
                     responder.log.debug('Enqueueing disconnected message')
-                    coroutines.append(responder.enqueue_task(responder.send(message)))
+                    coroutines.append(responder.jobs.enqueue(responder.send(message)))
                 try:
                     await asyncio.gather(*coroutines, loop=self._loop)
                 except Exception as exc:
@@ -342,13 +344,13 @@ class ServerProtocol:
                 except KeyError:
                     pass  # No initiator present
                 else:
-                    # Create message and add send coroutine to task queue of the
+                    # Create message and add send coroutine to job queue of the
                     # initiator
                     message = DisconnectedMessage.create(
                         INITIATOR_ADDRESS, ResponderAddress(client.id))
                     initiator.log.debug('Enqueueing disconnected message')
                     try:
-                        await initiator.enqueue_task(initiator.send(message))
+                        await initiator.jobs.enqueue(initiator.send(message))
                     except Exception as exc:
                         description = 'Error while dispatching disconnected message' \
                                       'to initiator:'
@@ -368,7 +370,7 @@ class ServerProtocol:
         self._server.unregister(self)
         client.log.debug('Worker stopped')
 
-    async def close(self, code: CloseCode) -> None:
+    def close(self, code: CloseCode) -> None:
         """
         Close the underlying connection and stop the protocol.
 
@@ -381,7 +383,7 @@ class ServerProtocol:
         if self.client is not None:
             # We need to use 'drop' in order to prevent the server from sending a
             # 'disconnect' message for each client.
-            await self._drop_client(self.client, code)
+            self._drop_client(self.client, code)
 
     def get_path_client(
             self,
@@ -424,151 +426,79 @@ class ServerProtocol:
         path, client = self.path, self.client
         assert path is not None
         assert client is not None
+        tasks = set()  # type: Set[Coroutine[Any, Any, None]]
 
         # Do handshake
         client.log.debug('Starting handshake')
-        await self.handshake()
+        try:
+            await self.handshake()
+        except Exception as exc:
+            client.log.info('Handshake aborted')
 
-        # Check if the client is still connected to the path or has already been dropped.
-        # Note: This can happen when the client is being picked up and dropped by another
-        #       client while running the handshake. To prevent other race conditions, we
-        #       have to add the client instance to the path early during the handshake.
-        is_connected = path.has_client(client)
-        if is_connected:
-            client.log.info('Handshake completed')
+            # Encountered an exception during the handshake.
+            # Note: We already know the result (the exception), so we can cancel both
+            #       job queue and tasks.
+            client.jobs.cancel()
+            client.tasks.cancel(Result(exc))
         else:
-            client.log.info('Handshake completed but client already dropped')
-
-        # Task: Execute enqueued tasks
-        client.log.debug('Starting to poll for enqueued tasks')
-        task_loop = self.task_loop()
-
-        # Task: Poll for messages
-        hex_path = PathHex(binascii.hexlify(path.initiator_key).decode('ascii'))
-        receive_loop = None  # type: Optional[Coroutine[Any, Any, None]]
-        if client.type == AddressType.initiator:
-            self._server.notify_initiator_connected(hex_path)
+            # Check if the client is still connected to the path or has already been
+            # dropped.
+            #
+            # Note: This can happen when the client is being picked up and dropped by
+            #       another client while running the handshake. To prevent other race
+            #       conditions, we have to add the client instance to the path early
+            #       during the handshake.
+            is_connected = path.has_client(client)
             if is_connected:
-                client.log.debug('Starting runner for initiator')
-                receive_loop = self.initiator_receive_loop()
-        elif client.type == AddressType.responder:
-            self._server.notify_responder_connected(hex_path)
+                client.log.info('Handshake completed')
+            else:
+                client.log.info('Handshake completed but client already dropped')
+
+            # Task: Poll for messages
+            hex_path = PathHex(binascii.hexlify(path.initiator_key).decode('ascii'))
+            if client.type == AddressType.initiator:
+                self._server.notify_initiator_connected(hex_path)
+                if is_connected:
+                    client.log.debug('Starting runner for initiator')
+                    tasks.add(self.initiator_receive_loop())
+            elif client.type == AddressType.responder:
+                self._server.notify_responder_connected(hex_path)
+                if is_connected:
+                    client.log.debug('Starting runner for responder')
+                    tasks.add(self.responder_receive_loop())
+            else:
+                raise ValueError('Invalid address type: {}'.format(client.type))
+
+            # Task: Keep alive
             if is_connected:
-                client.log.debug('Starting runner for responder')
-                receive_loop = self.responder_receive_loop()
-        else:
-            raise ValueError('Invalid address type: {}'.format(client.type))
+                client.log.debug('Starting keep-alive task')
+                tasks.add(self.keep_alive_loop())
 
-        # Task: Keep alive
-        keep_alive_loop = None  # type: Optional[Coroutine[Any, Any, None]]
-        if is_connected:
-            client.log.debug('Starting keep-alive task')
-            keep_alive_loop = self.keep_alive_loop()
-
-        # Set the tasks
-        client.tasks.set(
-            self._loop.create_task(task_loop),
-            None if receive_loop is None else self._loop.create_task(receive_loop),
-            None if keep_alive_loop is None else self._loop.create_task(keep_alive_loop),
-        )
-
-        # If already disconnected, schedule stopping of the task loop
-        if not is_connected:
-            client.stop_task_queue(immediate=True)
+        # Start the tasks and the job queue runner
+        client.jobs.start(client.tasks.cancel)
+        client.tasks.start(tasks)
 
         # Wait until complete
-        #
-        # Note: We also add the task loop into this list to catch any errors that bubble
-        #       up in tasks of this client.
-        #
-        # Warning: This is probably the most brittle piece of code in the server.
-        #          It is an absolute disaster and I hate myself for having done it this
-        #          way. My sincere apologies if you have to touch this.
-        tasks = set(client.tasks.valid)  # type: Set[Awaitable[None]]
-        while True:
-            done, pending = await asyncio.wait(
-                tasks, loop=self._loop, return_when=asyncio.FIRST_COMPLETED)
-            is_connected = path.has_client(client)
-            exc = None  # type: Optional[BaseException]
-            for task in done:
-                client.log.debug('Task done {}, connected={}', task, is_connected)
+        # Note: This method ensures us that all tasks have been cancelled
+        #       when it returns.
+        result = await client.tasks.await_result()
 
-                # Determine the exception to be raised
-                # Note: The first task will set the exception that will be raised.
-                if task.cancelled():
-                    if task != client.tasks.task_loop and not is_connected:
-                        # If the client has been dropped, we need to wait for the task
-                        # loop to return. So, remove the task from the list and continue.
-                        tasks.remove(task)
-                        break
-                    if exc is None:
-                        exc = InternalError('A vital task has been cancelled')
-                    client.log.error('Task {} has been cancelled', task)
-                    continue
+        # Cancel pending jobs and remove client from path
+        # Note: Removing the client needs to be done here since the re-raise hands
+        #       the task back into the event loop allowing other tasks to get the
+        #       client's path instance from the path while it is already effectively
+        #       disconnected.
+        client.jobs.cancel()
+        try:
+            path.remove_client(client)
+        except KeyError:
+            # We can safely ignore this since clients will be removed immediately
+            # from the path in case they are being dropped by another client.
+            pass
+        self._server.paths.clean(path)
 
-                task_exc = task.exception()
-                if task_exc is None:
-                    connection_closed_future = client.connection_closed_future
-
-                    # Tasks are allowed to return when the connection has been closed.
-                    # Note: This can happen in case a task returned due to the
-                    #       connection becoming closed. Since this doesn't raise an
-                    #       exception, we need to do it ourselves.
-                    if connection_closed_future.done():
-                        task_exc = Disconnected(connection_closed_future.result())
-                    else:
-                        # The task loop is allowed to return early if the task queue has
-                        # been closed or cancelled and all tasks have been processed
-                        if task == client.tasks.task_loop:
-                            if client.task_queue_done():
-                                tasks.remove(task)
-                                continue
-                            task_exc = InternalError(
-                                'Task loop {} returned unexpectedly', task)
-                        else:
-                            # All other tasks are not allowed to return early
-                            client.log.error('Task {} returned unexpectedly', task)
-                            task_exc = InternalError('A task returned unexpectedly')
-
-                if exc is None:
-                    exc = task_exc
-
-            # Continue if we have no exception
-            # Note: This happens when the task loop returns early after it has been
-            #       stopped.
-            #       This may also happen in case the client has been dropped and we need
-            #       to wait for the task loop to return.
-            if exc is None:
-                continue
-
-            # Cancel pending tasks
-            # Note: This excludes the task loop but cancels the currently awaited
-            #       task of the task loop.
-            for pending_task in pending:
-                if pending_task == client.tasks.task_loop:
-                    if (client.tasks.active_task is not None and
-                            client.tasks.active_task is not TaskLoopStopSentinel):
-                        util.cancel_awaitable(client.tasks.active_task, client.log)
-                else:
-                    client.log.debug('Cancelling pending task {}', pending_task)
-                    pending_task.cancel()
-
-            # Cancel the task queue and remove client from path
-            # Note: Removing the client needs to be done here since the re-raise hands
-            #       the task back into the event loop allowing other tasks to get the
-            #       client's path instance from the path while it is already effectively
-            #       disconnected.
-            client.cancel_task_queue()
-            try:
-                path.remove_client(client)
-            except KeyError:
-                # We can safely ignore this since clients will be removed immediately
-                # from the path in case they are being dropped by another client.
-                pass
-            self._server.paths.clean(path)
-
-            # Finally, raise the exception
-            raise exc
+        # Done! Raise the result
+        raise result
 
     async def handshake(self) -> None:
         """
@@ -623,10 +553,9 @@ class ServerProtocol:
         # Authenticated
         previous_initiator = path.set_initiator(initiator)
         if previous_initiator is not None:
-            # Drop previous initiator using its task queue
+            # Drop previous initiator using its job queue
             path.log.debug('Dropping previous initiator {}', previous_initiator)
             previous_initiator.log.debug('Dropping (another initiator connected)')
-            # noinspection PyAsyncCall
             self._drop_client(previous_initiator, CloseCode.drop_by_initiator)
 
         # Send new-initiator message if any responder is present
@@ -635,10 +564,10 @@ class ServerProtocol:
         for responder_id in responder_ids:
             responder = path.get_responder(responder_id)
 
-            # Create message and add send coroutine to task queue of the responder
+            # Create message and add send coroutine to job queue of the responder
             new_initiator = NewInitiatorMessage.create(responder_id)
             responder.log.debug('Enqueueing new-initiator message')
-            coroutines.append(responder.enqueue_task(responder.send(new_initiator)))
+            coroutines.append(responder.jobs.enqueue(responder.send(new_initiator)))
         await asyncio.gather(*coroutines, loop=self._loop)
 
         # Send server-auth
@@ -685,10 +614,10 @@ class ServerProtocol:
         except KeyError:
             pass
         else:
-            # Create message and add send coroutine to task queue of the initiator
+            # Create message and add send coroutine to job queue of the initiator
             new_responder = NewResponderMessage.create(id_)
             initiator.log.debug('Enqueueing new-responder message')
-            await initiator.enqueue_task(initiator.send(new_responder))
+            await initiator.jobs.enqueue(initiator.send(new_responder))
 
         # Send server-auth
         server_auth = ServerAuthMessage.create(
@@ -698,42 +627,11 @@ class ServerProtocol:
         responder.log.debug('Sending server-auth without responder ids')
         await responder.send(server_auth)
 
-    async def task_loop(self) -> None:
-        client = self.client
-        assert client is not None
-        while True:
-            # Get a task from the queue
-            task = await client.dequeue_task()
-            client.tasks.active_task = task
-            if task is TaskLoopStopSentinel:
-                client.task_done(task)
-                break
-
-            # Wait and handle exceptions
-            future = asyncio.ensure_future(cast(Awaitable[None], task), loop=self._loop)
-            client.log.debug('Waiting for task to complete {}', future)
-            try:
-                await future
-            except Exception as exc:
-                need_raise = True
-                if isinstance(exc, asyncio.CancelledError):
-                    client.log.debug('Active task cancelled {}', future)
-                    need_raise = False
-                else:
-                    client.log.debug('Stopping active task {}', future)
-                future.add_done_callback(client.task_done)
-                if need_raise:
-                    raise
-            else:
-                client.task_done(future)
-
-        client.log.debug('Task loop returned')
-
-    async def initiator_receive_loop(self) -> None:
+    async def initiator_receive_loop(self) -> NoReturn:
         path, initiator = self.path, self.client
         assert path is not None
         assert initiator is not None
-        while not initiator.connection_closed_future.done():
+        while True:
             # Receive relay message or drop-responder
             message = await initiator.receive()
 
@@ -758,22 +656,21 @@ class ServerProtocol:
                     log_message = 'Responder {} already dropped, nothing to do'
                     path.log.debug(log_message, message.responder_id)
                 else:
-                    # Drop responder using its task queue
+                    # Drop responder using its job queue
                     path.log.debug(
                         'Dropping responder {}, reason: {}', responder, message.reason)
                     responder.log.debug(
                         'Dropping (requested by initiator), reason: {}', message.reason)
-                    # noinspection PyAsyncCall
                     self._drop_client(responder, CloseCode(message.reason))
             else:
                 error = "Expected relay message or 'drop-responder', got '{}'"
                 raise MessageFlowError(error.format(message.type))
 
-    async def responder_receive_loop(self) -> None:
+    async def responder_receive_loop(self) -> NoReturn:
         path, responder = self.path, self.client
         assert path is not None
         assert responder is not None
-        while not responder.connection_closed_future.done():
+        while True:
             # Receive relay message
             message = await responder.receive()
 
@@ -806,10 +703,10 @@ class ServerProtocol:
 
         async def send_error_message() -> None:
             assert source is not None
-            # Create message and add send coroutine to task queue of the source
+            # Create message and add send coroutine to job queue of the source
             error = SendErrorMessage.create(ClientAddress(source.id), message_id)
             source.log.info('Relaying failed, enqueuing send-error')
-            await source.enqueue_task(source.send(error))
+            await source.jobs.enqueue(source.send(error))
 
         # Destination not connected? Send 'send-error' to source
         if destination is None:
@@ -819,10 +716,10 @@ class ServerProtocol:
             await send_error_message()
             return
 
-        # Add send task to task queue of the destination
+        # Add send task to job queue of the destination
         task = self._loop.create_task(destination.send(message))
         destination.log.debug('Enqueueing relayed message from 0x{:02x}', source.id)
-        await destination.enqueue_task(task)
+        await destination.jobs.enqueue(task)
 
         # noinspection PyBroadException
         try:
@@ -835,8 +732,8 @@ class ServerProtocol:
             await send_error_message()
         except Exception:
             # An exception has been triggered while sending the message.
-            # Note: We don't care about the actual exception as the task
-            #       loop will also trigger that exception on the
+            # Note: We don't care about the actual exception as the job
+            #       queue runner will also trigger that exception on the
             #       destination client's handler who will log what happened.
             log_message = 'Sending relayed message failed, receiver 0x{:02x} is gone'
             source.log.info(log_message, destination_id)
@@ -845,14 +742,14 @@ class ServerProtocol:
             source.log.debug('Sending relayed message to 0x{:02x} successful',
                              destination.id)
 
-    async def keep_alive_loop(self) -> None:
+    async def keep_alive_loop(self) -> NoReturn:
         """
         Disconnected
         PingTimeoutError
         """
         client = self.client
         assert client is not None
-        while not client.connection_closed_future.done():
+        while True:
             # Wait
             # noinspection PyTypeChecker
             await asyncio.sleep(client.keep_alive_interval, loop=self._loop)
@@ -940,11 +837,10 @@ class ServerProtocol:
         if chosen != self.subprotocol.value:
             raise DowngradeError('Subprotocol downgrade detected')
 
-    def _drop_client(self, client: PathClient, code: CloseCode) -> 'asyncio.Task[None]':
+    def _drop_client(self, client: PathClient, code: CloseCode) -> None:
         """
         Mark the client as closed, schedule the closing procedure on
-        the client's task queue, remove it from the path and return the
-        drop operation in form of a :class:`asyncio.Task`.
+        the client's job queue and remove it from the path.
 
         .. important:: This should only be called by clients dropping
                        another client or when the server is closing.
@@ -954,14 +850,12 @@ class ServerProtocol:
             - `close`: The close code.
         """
         # Drop the client
-        drop_task = client.drop(code)
+        client.drop(code)
 
         # Remove the client from the path
         path = self.path
         assert path is not None
         path.remove_client(client)
-
-        return drop_task
 
 
 class Paths:
@@ -1139,9 +1033,8 @@ class Server:
         if len(self.protocols) > 0:
             async def _close_and_wait() -> None:
                 # Wait until all connections have been scheduled to be closed
-                close_tasks = [protocol.close(CloseCode.going_away)
-                               for protocol in self.protocols]
-                await asyncio.gather(*close_tasks, loop=self._loop)
+                for protocol in self.protocols:
+                    protocol.close(CloseCode.going_away)
 
                 # Wait until all protocols have returned
                 handler_tasks = [protocol.handler_task for protocol in self.protocols]

--- a/saltyrtc/server/server.py
+++ b/saltyrtc/server/server.py
@@ -438,8 +438,9 @@ class ServerProtocol:
             # Encountered an exception during the handshake.
             # Note: We already know the result (the exception), so we can cancel both
             #       job queue and tasks.
-            client.jobs.cancel()
-            client.tasks.cancel(Result(exc))
+            result = Result(exc)
+            client.jobs.cancel(result)
+            client.tasks.cancel(result)
         else:
             # Check if the client is still connected to the path or has already been
             # dropped.
@@ -488,7 +489,7 @@ class ServerProtocol:
         #       the task back into the event loop allowing other tasks to get the
         #       client's path instance from the path while it is already effectively
         #       disconnected.
-        client.jobs.cancel()
+        client.jobs.cancel(result)
         try:
             path.remove_client(client)
         except KeyError:

--- a/saltyrtc/server/task.py
+++ b/saltyrtc/server/task.py
@@ -280,7 +280,6 @@ class JobQueue:
         # Enqueue any last minute jobs and ask the job queue runner to stop
         # Warning: put_nowait can raise if we limit the queue size!
         for job in jobs:
-
             self._queue.put_nowait(job)
         self._queue.put_nowait(self._final_job)
 
@@ -434,11 +433,10 @@ class Tasks:
             # Err... what the... ?
             self._log.exception('Task done but not done... what the...', exc_)
             exc = exc_
-        else:
-            # Tasks may not ever return without an exception
-            if exc is None:
-                result = task.result()
-                exc = InternalError('Task returned unexpectedly with {}', result)
+        # Tasks may not ever return without an exception
+        if exc is None:
+            result = task.result()
+            exc = InternalError('Task returned unexpectedly with {}', result)
 
         # Store the result and cancel all running tasks
         _log_exception(self._log, 'Task', exc)

--- a/saltyrtc/server/task.py
+++ b/saltyrtc/server/task.py
@@ -1,0 +1,455 @@
+import asyncio
+import enum
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Optional,
+    Set,
+    Union,
+    cast,
+)
+
+from . import util
+from .exception import (
+    Disconnected,
+    InternalError,
+    PingTimeoutError,
+    ServerKeyError,
+    SignalingError,
+    SlotsFullError,
+)
+from .typing import (
+    Job,
+    Logger,
+    Result,
+)
+
+__all__ = (
+    'FinalJob',
+    'JobQueue',
+    'Tasks',
+)
+
+
+def _log_exception(log: Logger, name: str, exc: BaseException) -> None:
+    # Handle exception
+    if isinstance(exc, Disconnected):
+        log.debug('{} returned due to connection closed (code: {})',
+                  name, exc.reason)
+    elif isinstance(exc, PingTimeoutError):
+        log.debug('{} returned due to ping timeout', name)
+    elif isinstance(exc, SlotsFullError):
+        log.debug('{} returned due to all path slots full: {}',
+                  name, exc)
+    elif isinstance(exc, ServerKeyError):
+        log.debug('{} returned due to server key error: {}', name, exc)
+    elif isinstance(exc, InternalError):
+        log.error('{} returned due to an internal error: {}', name, exc)
+    elif isinstance(exc, SignalingError):
+        log.debug('{} returned due to protocol error: {}', name, exc)
+    else:
+        log.error('{} returned due to exception: {}', name, exc)
+
+
+class FinalJob:
+    """
+    The job queue runner will stop if this has been dequeued from
+    the job queue and the inner awaitable has returned a result.
+    """
+    def __init__(
+            self,
+            result_future: 'asyncio.Future[Result]',
+            loop: asyncio.AbstractEventLoop,
+    ):
+        self.result_future = asyncio.shield(result_future, loop=loop)
+
+
+@enum.unique
+class JobQueueState(enum.IntEnum):
+    open = 1
+    closed = 2
+    cancelled = 3
+    completed = 4
+
+
+class JobQueue:
+    """
+    An ordered queue of jobs (coroutines) which can be enqueued.
+
+    A job queue runner can be started once ready which will process
+    jobs, one by one.
+
+    Once closed, the runner will continue to process pending jobs but
+    no further jobs can be enqueued.
+
+    When cancelled, all pending jobs will be cancelled and the runner
+    will be stopped.
+
+    Joining the job queue will block until all pending jobs have been
+    processed.
+    """
+    __slots__ = (
+        '_log',
+        '_loop',
+        '_state',
+        '_queue',
+        '_runner',
+        '_active_job',
+        '_final_job',
+    )
+
+    def __init__(
+            self,
+            log: Logger,
+            loop: asyncio.AbstractEventLoop,
+            final_job: FinalJob,
+    ) -> None:
+        self._log = log
+        self._loop = loop
+        self._state = JobQueueState.open  # type: JobQueueState
+        self._queue = \
+            asyncio.Queue(loop=self._loop)  # type: asyncio.Queue[Union[Job, FinalJob]]
+
+        # Job runner
+        self._runner = None  # type: Optional[asyncio.Task[None]]
+        self._active_job = None  # type: Optional[Job]
+        self._final_job = final_job
+
+    async def enqueue(self, job: Job) -> None:
+        """
+        Enqueue a job into the job queue of the client.
+
+        .. important:: Only the following jobs shall be enqueued:
+                       - Messages from the server towards this client.
+                       - Messages from other clients **towards** this
+                         client (i.e. relayed messages).
+                       - Delayed close operations towards this client.
+
+        .. note:: Coroutines will be closed and :class:`asyncio.Task`s
+                  will be cancelled when the job queue has been closed
+                  or cancelled. The awaitable must be prepared for that.
+
+        Arguments:
+            - `job`: A coroutine or a :class:`asyncio.Task`.
+        """
+        if self._state == JobQueueState.open:
+            await self._queue.put(job)
+        else:
+            util.cancel_awaitable(job, self._log)
+
+    def close(self, *jobs: Job) -> None:
+        """
+        Close the job queue to prevent further enqueues. Will do
+        nothing in case the job queue has already been closed or
+        cancelled.
+
+        Arguments:
+            - `jobs`: A sequence of jobs that will be enqueued before
+              the job queue is being closed.
+
+        .. note:: Coroutines will be closed and :class:`asyncio.Task`s
+                  will be cancelled when the job queue has been closed
+                  or cancelled. The awaitable must be prepared for that.
+
+        .. note:: Unlike :func:`~JobQueue.cancel`, this does
+                  not cancel any pending jobs.
+        """
+        # Ignore if already closed or cancelled
+        if self._state >= JobQueueState.closed:
+            for job in jobs:
+                util.cancel_awaitable(job, self._log)
+            return
+
+        # Update state
+        self._state = JobQueueState.closed
+        self._log.debug('Closed job queue')
+
+        # Ask the job queue runner to stop when done processing all previous jobs.
+        self._stop(*jobs)
+
+    def cancel(self) -> None:
+        """
+        Cancel all pending jobs of the job queue and prevent further
+        enqueues. Will do nothing in case the job queue has already
+        been cancelled.
+        """
+        # Ignore if already cancelled
+        if self._state >= JobQueueState.cancelled:
+            return
+
+        # Cancel active and all pending jobs
+        self._cancel()
+
+        # Ask the job queue runner to stop asap.
+        # Note: If the final job had been enqueued formerly, it would have been
+        #       dequeued in the block above, so we need to re-enqueue it.
+        self._stop()
+
+    async def join(self) -> None:
+        """
+        Block until all jobs of the job queue have been processed.
+
+        Raises :exc:`InternalError` in case the job queue runner is not
+        active.
+        """
+        self._log.debug(
+            'Joining job queue (state={}, #jobs={})',
+            self._state.name, self._queue.qsize())
+
+        # Ensure the job queue runner started
+        if self._runner is None:
+            raise InternalError('Tried joining but job queue runner not started')
+
+        # Join and wait for the job queue runner to exit
+        try:
+            await asyncio.gather(self._queue.join(), self._runner, loop=self._loop)
+        except asyncio.CancelledError:
+            # Cancel active job and all pending jobs
+            self._cancel()
+
+    def start(self, result_handler: Callable[[Result], None]) -> None:
+        """
+        Start the task queue runner.
+
+        Will call `result_handler` each time a processed job raises
+        an exception.
+
+        Raises :exc:`InternalError` in case the job queue runner is
+        already running.
+        """
+        if self._runner is not None:
+            raise InternalError('Tried starting but job queue runner already active')
+
+        # Start
+        self._log.debug('Job queue runner started')
+        self._runner = self._loop.create_task(self._run(result_handler))
+
+    def _cancel(self) -> None:
+        """
+        Cancel active and all pending jobs. Return whether the final
+        job has been removed.
+
+        Add a 'done' callback to each job in order to mark the job
+        queue as 'closed' after all functions, which may want to handle
+        the cancellation, have handled that cancellation.
+
+        This for example prevents a 'disconnect' message from being
+        sent before a 'send-error' message has been sent, see:
+        https://github.com/saltyrtc/saltyrtc-server-python/issues/77
+        """
+        if self._state < JobQueueState.cancelled:
+            self._state = JobQueueState.cancelled
+        if self._active_job is not None:
+            self._log.debug('Cancelling active job')
+            # Note: We explicitly DO NOT add the 'job done' callback here since the job
+            #       does that in all cases.
+            util.cancel_awaitable(self._active_job, self._log)
+            self._active_job = None
+        self._log.debug('Cancelling {} queued jobs', self._queue.qsize())
+        while True:
+            try:
+                job = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if job is self._final_job:
+                self._job_done(job, silent=True)
+            else:
+                awaitable = cast(Awaitable[None], job)
+                util.cancel_awaitable(awaitable, self._log, done_cb=self._job_done)
+
+    def _job_done(self, job: Union[Job, FinalJob], silent: bool = False) -> None:
+        """
+        Mark a previously dequeued job as processed.
+
+        Raises :exc:`InternalError` if called more times than there
+        were jobs placed in the queue.
+        """
+        if not silent:
+            self._log.debug('Job done {}', job)
+        try:
+            self._queue.task_done()
+        except ValueError:
+            raise InternalError('More jobs marked as done as were enqueued')
+
+    def _stop(self, *jobs: Job) -> None:
+        """
+        Ask the job queue runner to stop eventually.
+        """
+        # Enqueue any last minute jobs and ask the job queue runner to stop
+        # Warning: put_nowait can raise if we limit the queue size!
+        for job in jobs:
+
+            self._queue.put_nowait(job)
+        self._queue.put_nowait(self._final_job)
+
+    async def _run(self, result_handler: Callable[[Result], None]) -> None:
+        """
+        Process jobs until stopped.
+
+        Will call `exception_handler`, cancel all pending jobs and exit
+        in the next iteration when a job has raised an exception.
+        """
+        while True:
+            # Get a job from the queue
+            job = await self._queue.get()
+            if job is self._final_job:
+                self._state = JobQueueState.completed
+                result = await self._final_job.result_future
+                self._job_done(job)
+                result_handler(result)
+                break
+
+            # Wait until complete and handle exceptions
+            future = asyncio.ensure_future(cast(Awaitable[None], job), loop=self._loop)
+            self._log.debug('Waiting for job to complete {}', future)
+            self._active_job = future
+            try:
+                await future
+            except BaseException as exc:
+                self._active_job = None
+                if isinstance(exc, asyncio.CancelledError):
+                    self._log.debug('Active job cancelled {}', future)
+                else:
+                    self._log.debug('Stopping active job {}', future)
+                    _log_exception(self._log, 'Job', exc)
+                    self.cancel()
+                    result_handler(Result(exc))
+                # noinspection PyTypeChecker
+                future.add_done_callback(self._job_done)
+            else:
+                self._active_job = None
+                self._job_done(future)
+
+        # Bye
+        self._log.debug('Job queue runner done')
+
+
+class Tasks:
+    """
+    Contains one or more tasks that can be started at once.
+
+    Tasks are expected to return with an exception. They may also be
+    cancelled as long as a result (in form of an exception) has been
+    determined.
+    """
+    __slots__ = (
+        '_log',
+        '_loop',
+        '_cancelled',
+        '_result_set',
+        '_result_future',
+        '_tasks',
+        '_tasks_remaining',
+    )
+
+    def __init__(
+            self,
+            log: Logger,
+            loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        self._log = log
+        self._loop = loop
+        self._cancelled = False
+        self._result_set = False
+        self._result_future = \
+            asyncio.Future(loop=self._loop)  # type: asyncio.Future[Result]
+        self._tasks = None  # type: Optional[Set[asyncio.Task[None]]]
+        self._tasks_remaining = 0
+
+    def start(self, coroutines: Set[Coroutine[Any, Any, None]]) -> None:
+        """
+        Start coroutines by transforming them to tasks.
+
+        Arguments:
+            - `coroutines`: A set of coroutines that **may never return**.
+
+        Raises :exc:`InternalError` if already started.
+
+        .. note:: All tasks will be immediately cancelled if requested
+                  by another client prior to this method being called.
+        """
+        if self._tasks is not None:
+            raise InternalError('Tasks already started')
+
+        # Bind done callbacks
+        tasks = {self._loop.create_task(coroutine) for coroutine in coroutines}
+        for task in tasks:
+            self._tasks_remaining += 1
+            task.add_done_callback(self._task_done_handler)
+
+        # Store tasks
+        self._tasks = tasks
+
+        # Cancel tasks?
+        if self._cancelled:
+            self._cancel()
+
+    def cancel(self, result: Union[Result, 'asyncio.Future[Result]']) -> None:
+        """
+        Cancel all tasks and all tasks that will be started in the
+        future.
+        """
+        if self._cancelled:
+            return
+
+        # Set result (immediate or delayed)
+        self._set_result(result)
+
+        # Cancel all tasks
+        self._cancel()
+        self._cancelled = True
+
+    def await_result(self) -> 'asyncio.Future[Result]':
+        """
+        Wait for a result.
+
+        Once the :class:`asyncio.Future` is done, all tasks are
+        guaranteed to be done as well.
+        """
+        return asyncio.shield(self._result_future, loop=self._loop)
+
+    def _task_done_handler(self, task: 'asyncio.Task[None]') -> None:
+        assert self._tasks is not None
+        self._tasks_remaining -= 1
+        self._log.debug('Task done (#tasks={}, #running={}), {}',
+                        len(self._tasks), self._tasks_remaining, task)
+
+        # We don't care about cancelled tasks unless it's the last one and no exception
+        # has been set.
+        if task.cancelled():
+            self._log.debug('Task was cancelled')
+            if self._tasks_remaining == 0 and not self._result_set:
+                error = 'All tasks have been cancelled prior to an exception'
+                self._set_result(Result(InternalError(error)))
+                self._cancelled = True
+            return
+
+        # Tasks may not ever return without an exception
+        exc = task.exception()
+        if exc is None:
+            exc = InternalError('Task returned unexpectedly')
+        result = Result(exc)
+
+        # Store the result and cancel all running tasks
+        _log_exception(self._log, 'Task', exc)
+        self._set_result(result)
+        self._cancel()
+
+    def _set_result(self, result: Union[Result, 'asyncio.Future[Result]']) -> None:
+        if not self._result_set:
+            self._log.debug('Tasks result: {}, cancelling all remaining', type(result))
+            self._result_set = True
+            if isinstance(result, BaseException):
+                self._result_future.set_result(result)
+            else:
+                result.add_done_callback(
+                    lambda future: self._result_future.set_result(future.result()))
+
+    def _cancel(self) -> None:
+        if self._tasks is None:
+            return
+        for task in self._tasks:
+            if not task.done():
+                task.cancel()

--- a/saltyrtc/server/typing.py
+++ b/saltyrtc/server/typing.py
@@ -8,7 +8,6 @@ from typing import (
     NewType,
     Optional,
     Tuple,
-    Type,
     TypeVar,
     Union,
 )
@@ -17,7 +16,7 @@ import libnacl.public
 
 if TYPE_CHECKING:
     # noinspection PyUnresolvedReferences
-    from .common import TaskLoopStopSentinel  # noqa
+    import logbook  # noqa
     # noinspection PyUnresolvedReferences
     from .events import Event  # noqa
 
@@ -50,7 +49,9 @@ __all__ = (
     'ServerSecretSessionKey',
     'MessageBox',
     'SignBox',
-    'Task',
+    'Job',
+    'Result',
+    'Logger',
     'LogbookLevel',
     'LoggingLevel',
 )
@@ -152,13 +153,22 @@ ServerSecretSessionKey = NewType('ServerSecretSessionKey', libnacl.public.Secret
 MessageBox = NewType('MessageBox', libnacl.public.Box)
 # Box for "signing" the keys in the 'server-auth' message
 SignBox = NewType('SignBox', libnacl.public.Box)
-# A task for the task loop
-Task = Union[Awaitable[None], Type['TaskLoopStopSentinel']]
+# A job of the job queue
+Job = Awaitable[None]
+
+
+# Task
+# ----
+
+# A consolidated result
+Result = NewType('Result', BaseException)
 
 
 # Util
 # ----
 
+# :mod:`logbook` Logger abstraction
+Logger = Any
 # A :mod:`logbook` log level
 LogbookLevel = NewType('LogbookLevel', int)
 # A :mod:`logging` log level

--- a/saltyrtc/server/util.py
+++ b/saltyrtc/server/util.py
@@ -23,6 +23,7 @@ import libnacl.public
 
 from .typing import (
     LogbookLevel,
+    Logger,
     LoggingLevel,
     NoReturn,
     ServerSecretPermanentKey,
@@ -292,9 +293,9 @@ def load_permanent_key(key: str) -> ServerSecretPermanentKey:
 
 
 def cancel_awaitable(
-        awaitable: Awaitable[None],
-        log: 'logbook.Logger',
-        done_cb: Optional[Callable[[Awaitable[None]], Any]] = None
+        awaitable: Awaitable[Any],
+        log: Logger,
+        done_cb: Optional[Callable[[Awaitable[Any]], Any]] = None
 ) -> None:
     """
     Cancel a coroutine or a :class:`asyncio.Task`.
@@ -315,6 +316,7 @@ def cancel_awaitable(
     else:
         task = cast('asyncio.Task[None]', awaitable)
         if done_cb is not None:
+            # noinspection PyTypeChecker
             task.add_done_callback(done_cb)
         # Note: We need to check for .cancelled first since a task is also marked
         #       .done when it is cancelled.

--- a/saltyrtc/server/util.py
+++ b/saltyrtc/server/util.py
@@ -313,7 +313,7 @@ def cancel_awaitable(
           `coroutine_or_task` is a coroutine.
     """
     if asyncio.iscoroutine(awaitable):
-        coroutine = cast('Coroutine[Any, Any, None]', awaitable)
+        coroutine = cast(Coroutine[Any, Any, None], awaitable)
         log.debug('Closing coroutine {}', coroutine)
         coroutine.close()
         if done_cb is not None:

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ if platform.python_implementation() == 'PyPy':
     mypy_require = []
 else:
     mypy_require = [
-        'mypy==0.660',
+        'mypy==0.700',
     ]
 
 # Test requirements

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,10 @@ class CalledProcessError(subprocess.CalledProcessError):
 
 
 def pytest_addoption(parser):
+    # 'repeat' parameter
+    help_ = 'Number of times to repeat each test'
+    parser.addoption('--repeat', action='store', help=help_)
+
     # 'loop' parameter
     help_ = 'Use a different event loop, supported: asyncio, uvloop'
     parser.addoption('--loop', action='store', help=help_)
@@ -40,6 +44,13 @@ def pytest_addoption(parser):
     # 'timeout' parameter
     help_ = 'Use a specific timeout in seconds (float) for tests'
     parser.addoption('--timeout', action='store', help=help_)
+
+
+def pytest_generate_tests(metafunc):
+    if metafunc.config.option.repeat is not None:
+        count = int(metafunc.config.option.repeat)
+        metafunc.fixturenames.append('repeat')
+        metafunc.parametrize('repeat', range(count))
 
 
 def pytest_report_header(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,7 +299,7 @@ def server_factory(request, event_loop, server_permanent_keys):
     Return a factory to create :class:`saltyrtc.Server` instances.
     """
     # Enable asyncio debug logging
-    os.environ['PYTHONASYNCIODEBUG'] = '1'
+    event_loop.set_debug(True)
 
     # Enable logging
     util.enable_logging(level=logbook.DEBUG, redirect_loggers={
@@ -392,7 +392,7 @@ def evaluate_log(log_handler):
     errors = [record for record in log_handler.records
               if (record.level >= log_handler._error_level
                   and not log_handler._ignore_filter(record))]
-    assert(len(errors) == 0)
+    assert len(errors) == 0
 
 
 @pytest.fixture

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1378,9 +1378,8 @@ class TestProtocol:
         # been initiated
         class _MockProtocol(ServerProtocol):
             def _drop_client(self, *args, **kwargs):
-                result = super()._drop_client(*args, **kwargs)
+                super()._drop_client(*args, **kwargs)
                 done_future.set_result(None)
-                return result
 
         mocker.patch.object(server, '_protocol_class', _MockProtocol)
 
@@ -1407,7 +1406,7 @@ class TestProtocol:
             await done_future
 
         # Enqueue long-blocking task
-        await path_client.enqueue_task(blocking_task())
+        await path_client.jobs.enqueue(blocking_task())
 
         # Drop responder
         await initiator.send(pack_nonce(i['cck'], 0x01, 0x00, i['ccsn']), {

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1224,7 +1224,7 @@ class TestProtocol:
             self, pack_nonce, cookie_factory, server, client_factory
     ):
         """
-        Ensure a relay messages are being dispatched in case the client
+        Ensure relay messages are being dispatched in case the client
         closes after having sent a couple of relay messages.
         """
         # Initiator handshake
@@ -1500,6 +1500,58 @@ class TestProtocol:
         # Receive 'disconnected' message
         message, *_ = await initiator.recv()
         assert message == {'type': 'disconnected', 'id': r['id']}
+
+        # Bye
+        await initiator.close()
+        await responder.close()
+        await server.wait_connections_closed()
+
+    @pytest.mark.asyncio
+    async def test_relay_timeout(
+            self, mocker, sleep, initiator_key, pack_nonce,
+            cookie_factory, server, client_factory
+    ):
+        """
+        Ensure the server responds with a 'send-error' message when a
+        relay times out.
+        """
+        # Mock the job queue join timeout
+        mocker.patch('saltyrtc.server.server.RELAY_TIMEOUT', 0.1)
+
+        # Initiator handshake
+        initiator, i = await client_factory(initiator_handshake=True)
+        i['rccsn'] = 98798981
+        i['rcck'] = cookie_factory()
+
+        # Responder handshake
+        responder, r = await client_factory(responder_handshake=True)
+        r['iccsn'] = 2 ** 23
+        r['icck'] = cookie_factory()
+
+        # new-responder
+        await initiator.recv()
+
+        # Get responder's PathClient instance
+        path = server.paths.get(initiator_key.pk)
+        path_client = path.get_responder(r['id'])
+        send = path_client._connection.send
+
+        # Mock responder instance: Slow-motion sending
+        async def _mock_send(*args, **kwargs):
+            await sleep(0.2)
+            return await send(*args, **kwargs)
+
+        mocker.patch.object(path_client._connection, 'send', _mock_send)
+
+        # Send relay message: initiator --> responder
+        nonce = pack_nonce(i['rcck'], i['id'], r['id'], i['rccsn'])
+        await initiator.send(nonce, b'\xfe' * 2**15, box=None)
+        i['rccsn'] += 1
+
+        # Receive send-error message: initiator <-- initiator
+        message, *_ = await initiator.recv()
+        assert message['type'] == 'send-error'
+        assert len(message['id']) == 8
 
         # Bye
         await initiator.close()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -60,7 +60,7 @@ class TestServer:
         await server.wait_connections_closed()
         assert not initiator.ws_client.open
         assert initiator.ws_client.close_code == CloseCode.internal_error
-        assert len([record for record in log_handler.records if _filter(record)]) == 2
+        assert len([record for record in log_handler.records if _filter(record)]) == 1
 
     @pytest.mark.asyncio
     async def test_tasks_cancelled_connection_open(


### PR DESCRIPTION
Yay... again... this time we try to simplify tasks and jobs by giving them hard constraints.

A task:

* Must never return
* Must always exit with an exception

A job:

* May return or exit with an exception

The job queue runner:

* Does not exit before the job queue is closed or cancelled
* Must not return before the connection has been closed

To do:

- [x] Test with SaltyRTC Client Java
- [x] Test with SaltyRTC Client JS