### PR TITLE
Fix path duplication

### DIFF
--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1747,6 +1747,8 @@ class TestProtocol:
         # Add fake clients to path
         clients = [_FakePathClient() for _ in range(0x02, 0x100)]
         for client in clients:
+            path.add_pending(client)
+        for client in clients:
             path.add_responder(client)
 
         # Now the path is full


### PR DESCRIPTION
Fix a race condition that leads to path duplication

This adds a *pending* set of clients to the `Path` instance which prevents it from being removed while another client is currently in the handshake process.

Depends on #116