### PR TITLE
Upgrade dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,22 +60,6 @@ jobs:
       - EVENT_LOOP: uvloop
       - TIMEOUT: "2.0"
 
-  test-python-3_5-asyncio:
-    <<: *shared
-    docker:
-      - image: saltyrtc/circleci-image-python:python-3.5
-    environment:
-      - EVENT_LOOP: asyncio
-      - TIMEOUT: "2.0"
-
-  test-python-3_5-uvloop:
-    <<: *shared
-    docker:
-      - image: saltyrtc/circleci-image-python:python-3.5
-    environment:
-      - EVENT_LOOP: uvloop
-      - TIMEOUT: "2.0"
-
   lint:
     docker:
       - image: saltyrtc/circleci-image-python:python-3.7
@@ -160,8 +144,6 @@ workflows:
       - test-python-3_7-uvloop
       - test-python-3_6-asyncio
       - test-python-3_6-uvloop
-      - test-python-3_5-asyncio
-      - test-python-3_5-uvloop
   docker:
     jobs:
       - build-docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM python:3
 # Install dependencies
 RUN apt-get update -qqy \
  && apt-get install -qqy --no-install-recommends \
-    libsodium18 \
+    libsodium23 \
  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Set working directory

--- a/saltyrtc/server/__init__.py
+++ b/saltyrtc/server/__init__.py
@@ -1,5 +1,5 @@
 """
-This is a SaltyRTC server implementation for Python 3.5.3+ using
+This is a SaltyRTC server implementation for Python 3.6.1+ using
 :mod:`asyncio`.
 """
 import itertools

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-python-tag = py35.py36.py37
+python-tag = py36.py37
 
 [easy_install]
 zip_ok = false
@@ -38,9 +38,6 @@ ignore_missing_imports = true
 ignore_missing_imports = true
 
 [mypy-uvloop.*]
-ignore_missing_imports = true
-
-[mypy-websockets.*]
 ignore_missing_imports = true
 
 [tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ long_description = '\n\n'.join((read('README.rst'), read('CHANGELOG.rst')))
 
 # Check python version
 py_version = sys.version_info[:3]
-if py_version < (3, 5, 3):
-    raise Exception("SaltyRTC requires Python >= 3.5.3")
+if py_version < (3, 6, 1):
+    raise Exception("SaltyRTC requires Python >= 3.6.1")
 
 # Logging requirements
 logging_require = [
@@ -53,8 +53,8 @@ tests_require = [
     'pytest-asyncio>=0.9.0',
     'pytest-cov>=2.5.1',
     'pytest-mock>=1.10.0',
-    'flake8>=3.5.0',
-    'isort>=4.3.4',
+    'flake8>=3.7.8',
+    'isort>=4.3.21',
     'collective.checkdocs>=0.2',
     'Pygments>=2.2.0',  # required by checkdocs
     'ordered-set>=3.0.1',  # required by TestServer class
@@ -68,7 +68,7 @@ setup(
     install_requires=[
         'libnacl>=1.5.0,<2',
         'click>=6.7',  # doesn't seem to follow semantic versioning (see #57)
-        'websockets>=7.0,<8',
+        'websockets>=8.0,<9',
         'u-msgpack-python>=2.3,<3',
     ],
     tests_require=tests_require,
@@ -101,7 +101,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Topic :: Communications',

--- a/stubs/libnacl/public.pyi
+++ b/stubs/libnacl/public.pyi
@@ -6,7 +6,6 @@ from typing import (
 
 from .base import BaseKey
 
-
 class PublicKey(BaseKey):
     def __init__(self, pk: bytes) -> None: ...
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1381,7 +1381,7 @@ class TestProtocol:
                 super()._drop_client(*args, **kwargs)
                 done_future.set_result(None)
 
-        mocker.patch.object(server, '_protocol_class', _MockProtocol)
+        mocker.patch.object(server, 'protocol_class', _MockProtocol)
 
         # Initiator handshake
         initiator, i = await client_factory(initiator_handshake=True)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -51,7 +51,7 @@ class TestServer:
                 # ZZzzzZZzz
                 await sleep(0.1)
 
-        mocker.patch.object(server, '_protocol_class', _MockProtocol)
+        mocker.patch.object(server, 'protocol_class', _MockProtocol)
 
         # Initiator handshake
         initiator, _ = await client_factory(initiator_handshake=True)
@@ -93,7 +93,7 @@ class TestServer:
                 self._loop.create_task(_cancel_task(keep_alive_loop))
                 await keep_alive_loop
 
-        mocker.patch.object(server, '_protocol_class', _MockProtocol)
+        mocker.patch.object(server, 'protocol_class', _MockProtocol)
 
         # Initiator handshake
         initiator, _ = await client_factory(initiator_handshake=True)
@@ -117,7 +117,7 @@ class TestServer:
             async def keep_alive_loop(self):
                 await sleep(60.0)
 
-        mocker.patch.object(server, '_protocol_class', _MockProtocol)
+        mocker.patch.object(server, 'protocol_class', _MockProtocol)
 
         # Initiator handshake & disconnect immediately
         initiator, _ = await client_factory(initiator_handshake=True)
@@ -144,7 +144,7 @@ class TestServer:
                 await close_future
                 return await super().handshake()
 
-        mocker.patch.object(server, '_protocol_class', _MockProtocol)
+        mocker.patch.object(server, 'protocol_class', _MockProtocol)
 
         # Connect & disconnect immediately
         ws_client = await ws_client_factory()
@@ -182,7 +182,7 @@ class TestServer:
             async def keep_alive_loop(self):
                 await sleep(60.0)
 
-        mocker.patch.object(server, '_protocol_class', _MockProtocol)
+        mocker.patch.object(server, 'protocol_class', _MockProtocol)
 
         # Initiator handshake & disconnect immediately
         initiator, _ = await client_factory(initiator_handshake=True)
@@ -216,7 +216,7 @@ class TestServer:
                 await sleep(0.1)
                 raise result
 
-        mocker.patch.object(server, '_protocol_class', _MockProtocol)
+        mocker.patch.object(server, 'protocol_class', _MockProtocol)
 
         # Connect client to server
         ws_client = await ws_client_factory()
@@ -270,7 +270,7 @@ class TestServer:
                 # Wait until closed
                 raise await self.client.connection_closed_future
 
-        mocker.patch.object(server, '_protocol_class', _MockProtocol)
+        mocker.patch.object(server, 'protocol_class', _MockProtocol)
 
         # Create client and patch it to not answer pings
         ws_client = await ws_client_factory()
@@ -327,7 +327,13 @@ class TestServer:
         future.cancel()
 
         # Close on the job queue
-        await path_client.jobs.enqueue(initiator.close())
+        async def _wait_definitely_closed():
+            await initiator.close()
+            # Note: We need this since the 'close' coroutine may return before the
+            #       `Disconnected` exception has been thrown within the server.
+            await sleep(0.1)
+
+        await path_client.jobs.enqueue(_wait_definitely_closed())
 
         # Enqueue task and cancel immediately
         job = event_loop.create_task(sleep(60.0))
@@ -603,7 +609,7 @@ class TestServer:
                     await connection_closed_future()
                     raise
 
-        mocker.patch.object(server, '_protocol_class', _MockProtocol)
+        mocker.patch.object(server, 'protocol_class', _MockProtocol)
 
         # Responder handshake
         responder, _ = await client_factory(responder_handshake=True)
@@ -639,7 +645,7 @@ class TestServer:
                 super()._drop_client(client, code)
                 client_dropped_future.set_result(None)
 
-        mocker.patch.object(server, '_protocol_class', _MockProtocol)
+        mocker.patch.object(server, 'protocol_class', _MockProtocol)
 
         # First initiator handshake
         first_initiator, _ = await client_factory(initiator_handshake=True)
@@ -685,7 +691,7 @@ class TestServer:
                     cancelled_future.set_result(None)
                     raise
 
-        mocker.patch.object(server, '_protocol_class', _MockProtocol)
+        mocker.patch.object(server, 'protocol_class', _MockProtocol)
 
         # Initiator handshake
         initiator, i = await client_factory(initiator_handshake=True)
@@ -762,7 +768,7 @@ class TestServer:
                     cancelled_future.set_result(None)
                     raise
 
-        mocker.patch.object(server, '_protocol_class', _MockProtocol)
+        mocker.patch.object(server, 'protocol_class', _MockProtocol)
 
         # Initiator handshake
         initiator, i = await client_factory(initiator_handshake=True)


### PR DESCRIPTION
Upgrade websockets, flake8 and isort dependency.

Note: websockets >= 8.0 now requires upgrading Python >= 3.6.1, so this will require a major release.