### PR TITLE
Upgrade isort to version 5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ imports (``isort``), do a static type analysis and run the project's tests:
 .. code-block:: bash
 
     flake8 .
-    isort -rc .
+    isort .
     MYPYPATH=${PWD}/stubs mypy saltyrtc examples
     py.test
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,7 @@ Signing key: https://lgrahl.de/pub/pgp-key.txt
 
    ```bash
    flake8 .
-   isort -rc -c . || isort -rc -df
+   isort -c . || isort -df
    rm -rf .mypy_cache && MYPYPATH=${PWD}/stubs mypy saltyrtc examples
    py.test
    ```

--- a/examples/debug.py
+++ b/examples/debug.py
@@ -1,13 +1,13 @@
-import asyncio
-import os
-import ssl  # noqa
-import sys
 from typing import Any  # noqa
 from typing import Coroutine  # noqa
 from typing import List  # noqa
 from typing import Optional
 
+import asyncio
 import logbook.more
+import os
+import ssl  # noqa
+import sys
 
 import saltyrtc.server
 from saltyrtc.server.typing import ServerSecretPermanentKey  # noqa

--- a/examples/restartable.py
+++ b/examples/restartable.py
@@ -1,14 +1,14 @@
-import asyncio
-import os
-import signal
-import ssl  # noqa
-import sys
 from typing import Any  # noqa
 from typing import Coroutine  # noqa
 from typing import List  # noqa
 from typing import Optional
 
+import asyncio
 import logbook.more
+import os
+import signal
+import ssl  # noqa
+import sys
 
 import saltyrtc.server
 from saltyrtc.server.typing import ServerSecretPermanentKey  # noqa

--- a/saltyrtc/server/__init__.py
+++ b/saltyrtc/server/__init__.py
@@ -4,6 +4,16 @@ This is a SaltyRTC server implementation for Python 3.6.1+ using
 """
 import itertools
 
+from . import (
+    common,
+    events,
+    exception,
+    message,
+    protocol,
+    server,
+    task,
+    util,
+)
 from .common import *  # noqa
 from .events import *  # noqa
 from .exception import *  # noqa

--- a/saltyrtc/server/bin.py
+++ b/saltyrtc/server/bin.py
@@ -1,19 +1,19 @@
 """
 The command line interface for the SaltyRTC signalling server.
 """
-import asyncio
-import enum
-import os
-import signal
-import stat
 from typing import Coroutine  # noqa
 from typing import List  # noqa
 from typing import Optional  # noqa
 from typing import Sequence  # noqa
 from typing import Any
 
+import asyncio
 import click
+import enum
 import libnacl.public
+import os
+import signal
+import stat
 
 from . import (
     __version__ as _version,

--- a/saltyrtc/server/common.py
+++ b/saltyrtc/server/common.py
@@ -2,12 +2,13 @@
 This package will be moved to `saltyrtc.common` as soon as a SaltyRTC
 client is being written.
 """
-import enum
 from typing import (
     TYPE_CHECKING,
     Any,
     cast,
 )
+
+import enum
 
 from .exception import MessageError
 from .typing import (

--- a/saltyrtc/server/events.py
+++ b/saltyrtc/server/events.py
@@ -1,7 +1,8 @@
-import collections
-import enum
 from typing import Dict  # noqa
 from typing import List
+
+import collections
+import enum
 
 from .typing import EventCallback
 

--- a/saltyrtc/server/message.py
+++ b/saltyrtc/server/message.py
@@ -1,7 +1,3 @@
-import abc
-import binascii
-import io
-import struct
 from typing import ClassVar  # noqa
 from typing import (
     TYPE_CHECKING,
@@ -13,7 +9,11 @@ from typing import (
     cast,
 )
 
+import abc
+import binascii
+import io
 import libnacl
+import struct
 import umsgpack
 
 from .common import (

--- a/saltyrtc/server/protocol.py
+++ b/saltyrtc/server/protocol.py
@@ -1,6 +1,3 @@
-import asyncio
-import os
-import struct
 # noinspection PyUnresolvedReferences
 from typing import Dict  # noqa
 from typing import Set  # noqa
@@ -14,8 +11,11 @@ from typing import (
     cast,
 )
 
+import asyncio
 import libnacl
 import libnacl.public
+import os
+import struct
 import websockets
 
 from . import util

--- a/saltyrtc/server/server.py
+++ b/saltyrtc/server/server.py
@@ -1,8 +1,3 @@
-import asyncio
-import binascii
-import functools
-import ssl
-from collections import OrderedDict
 from typing import Awaitable  # noqa
 from typing import ClassVar  # noqa
 from typing import Dict  # noqa
@@ -22,7 +17,12 @@ from typing import (
     cast,
 )
 
+import asyncio
+import binascii
+import functools
+import ssl
 import websockets
+from collections import OrderedDict
 from websockets.typing import Subprotocol
 
 from . import util

--- a/saltyrtc/server/task.py
+++ b/saltyrtc/server/task.py
@@ -1,6 +1,3 @@
-import asyncio
-import enum
-import functools
 from typing import (
     Any,
     Callable,
@@ -9,6 +6,10 @@ from typing import (
     Set,
     Union,
 )
+
+import asyncio
+import enum
+import functools
 
 from . import util
 from .exception import (

--- a/saltyrtc/server/typing.py
+++ b/saltyrtc/server/typing.py
@@ -17,6 +17,7 @@ import libnacl.public
 if TYPE_CHECKING:
     # noinspection PyUnresolvedReferences
     import logbook  # noqa
+
     # noinspection PyUnresolvedReferences
     from .events import Event  # noqa
 

--- a/saltyrtc/server/util.py
+++ b/saltyrtc/server/util.py
@@ -2,10 +2,6 @@
 This module provides utility functions for the SaltyRTC Signalling
 Server.
 """
-import asyncio
-import binascii
-import logging
-import ssl
 # noinspection PyUnresolvedReferences
 from typing import Coroutine  # noqa
 from typing import (
@@ -19,8 +15,12 @@ from typing import (
     cast,
 )
 
+import asyncio
+import binascii
 import libnacl
 import libnacl.public
+import logging
+import ssl
 
 from .typing import (
     LogbookLevel,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ import ast
 import os
 import platform
 import sys
-
 from setuptools import setup
 
 
@@ -54,7 +53,7 @@ tests_require = [
     'pytest-cov>=2.5.1',
     'pytest-mock>=1.10.0',
     'flake8>=3.7.8',
-    'isort>=4.3.21',
+    'isort>=5,<6',
     'collective.checkdocs>=0.2',
     'Pygments>=2.2.0',  # required by checkdocs
     'ordered-set>=3.0.1',  # required by TestServer class

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,9 @@ else:
 #       is not necessary here.
 tests_require = [
     'pytest>=3.7.3,<4',
-    'pytest-asyncio>=0.9.0',
-    'pytest-cov>=2.5.1',
-    'pytest-mock>=1.10.0',
+    'pytest-asyncio>=0.9.0,<0.10',
+    'pytest-cov>=2.5.1,<3',
+    'pytest-mock>=1.10.0,<2',
     'flake8>=3.7.8',
     'isort>=5,<6',
     'collective.checkdocs>=0.2',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,18 @@
 import asyncio
 import functools
+import libnacl.public
+import logbook
+import ordered_set
 import os
+import pytest
 import socket
 import ssl
 import struct
 import subprocess
 import sys
-from contextlib import closing
-
-import libnacl.public
-import logbook
-import ordered_set
-import pytest
 import umsgpack
 import websockets
+from contextlib import closing
 
 from saltyrtc.server import (
     NONCE_FORMATTER,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,9 @@
 import binascii
 import os
+import pytest
 import signal
 import stat
 import subprocess
-
-import pytest
 
 from saltyrtc.server import (
     Server,

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -3,7 +3,6 @@ The tests provided in this module make sure that the server is
 compliant to the SaltyRTC protocol.
 """
 import asyncio
-
 import libnacl.public
 import pytest
 import websockets

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,7 +4,6 @@ instance behaves as expected.
 """
 import asyncio
 import collections
-
 import pytest
 
 from saltyrtc.server import (


### PR DESCRIPTION
It's now pinned to its major version, so that a new major release won't break our CI again.